### PR TITLE
docs: add back the title column from demo dataset

### DIFF
--- a/packages/docs/generate_demo_data.py
+++ b/packages/docs/generate_demo_data.py
@@ -50,6 +50,7 @@ def main(output: str):
 
     name = "spawn99/wine-reviews"
     columns = [
+        "title",
         "country",
         "province",
         "description",


### PR DESCRIPTION
As per #1 

I'd also like to add the following doc for future reference but couldn't decide which file it should live in.

```md
## Example data

The data is created as part of the [GitHub Actions](https://github.com/apple/embedding-atlas/blob/main/.github/workflows/ci.yml).

Which calls the following script

[embedding-atlas/blob/main/packages/docs/generate_demo_data.py](https://github.com/apple/embedding-atlas/blob/main/packages/docs/generate_demo_data.py)
```