### PR TITLE
feat: add additional header content API to table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1574,9 +1574,9 @@
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3563,9 +3563,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/packages/docs/table.md
+++ b/packages/docs/table.md
@@ -154,6 +154,10 @@ When provided, these all other rows will be dimmed in the table.
 
 You can use this to designate custom renderers for columns. A `CustomCellsConfig` is a `{ [column: string]: CustomCell }`. See [Custom Cells](#custom-cells) for more info.
 
+### additionalHeaderContents? `AdditionalHeaderContentsConfig`
+
+You can use this to designate additional content for column headers. Additional header content is rendered above the title of the header, and can be used to add helpful content such as summaries and visualizations to headers. A `AdditionalHeaderContentsConfig` is a `{ [column: string]: AdditionalHeaderContent }`. See [Additional Header Contents](#additional-header-contents) for more info.
+
 ## Custom Cells
 
 To use custom cell rendering, first create a class for the custom cell renderer:
@@ -184,6 +188,39 @@ Then specify the `customCells` property to the component for the desired column:
   ...
   customCells={{
     columnA: CustomCellRenderer,
+  }}
+/>
+```
+
+## Additional Header Contents
+
+Similar to custom cells, to add additional header content, first create a class for the additional header content:
+
+```ts
+interface AdditionalHeaderContentProps {
+  column: string;
+}
+
+class AdditionalHeaderContentRenderer {
+  constructor(target, props: AdditionalHeaderContentProps) {
+    // Create the cell component and mount it to the target element.
+  }
+  update(props: AdditionalHeaderContentProps) {
+    // Update the component with new props.
+  }
+  destroy() {
+    // Destroy the component.
+  }
+}
+```
+
+Then specify the `additionalHeaderContents` property to the component for the desired column:
+
+```svelte
+<EmbeddingViewMosaic
+  ...
+  additionalHeaderContents={{
+    columnA: AdditionalHeaderContentRenderer,
   }}
 />
 ```

--- a/packages/table/src/demo/AdditionalHeaderContentExample.svelte
+++ b/packages/table/src/demo/AdditionalHeaderContentExample.svelte
@@ -1,0 +1,16 @@
+<!-- Copyright (c) 2025 Apple Inc. Licensed under MIT License. -->
+<script lang="ts">
+  import type { AdditionalHeaderContentProps } from "../lib/api/custom-headers";
+
+  interface Props extends AdditionalHeaderContentProps {}
+
+  let { column }: Props = $props();
+</script>
+
+<div class="additional-header-content">Additional Header Content: {column}</div>
+
+<style>
+  .additional-header-content {
+    height: 100px;
+  }
+</style>

--- a/packages/table/src/demo/App.svelte
+++ b/packages/table/src/demo/App.svelte
@@ -5,9 +5,14 @@
   import { onMount } from "svelte";
 
   import { createCustomCellClass, type CustomCellsConfig } from "../lib/api/custom-cells.js";
+  import {
+    createAdditionalHeaderContentClass,
+    type AdditionalHeaderContentsConfig,
+  } from "../lib/api/custom-headers.js";
   import type { Theme } from "../lib/api/style.js";
   import type { ColumnConfigChangeCallback, ColumnConfigs } from "../lib/context/config.svelte.js";
   import Table from "../lib/Table.svelte";
+  import AdditionalHeaderContentExample from "./AdditionalHeaderContentExample.svelte";
   import CustomCellExample from "./CustomCellExample.svelte";
 
   let ready = $state(false);
@@ -74,6 +79,7 @@
   let colorScheme: "light" | "dark" = $state("light");
   let theme: Theme = $state({});
   let customCellsConfig: CustomCellsConfig = $state({});
+  let additionalHeaderContentsConfig: AdditionalHeaderContentsConfig = $state({});
   let showRowNumber: boolean = $state(true);
   let headerHeight: number | null = $state(null);
   let highlightedRows: number[] | null = $state([]);
@@ -148,6 +154,14 @@
     </button>
     <button
       onclick={() => {
+        additionalHeaderContentsConfig["entry_type"] =
+          createAdditionalHeaderContentClass(AdditionalHeaderContentExample);
+      }}
+    >
+      Additional Header Content
+    </button>
+    <button
+      onclick={() => {
         headerHeight = 32;
       }}
     >
@@ -176,6 +190,7 @@
         lineHeight={20}
         numLines={1}
         customCells={customCellsConfig}
+        additionalHeaderContents={additionalHeaderContentsConfig}
         headerHeight={headerHeight}
         onRowClick={(rowId) => {
           console.log("clicked row:", rowId);

--- a/packages/table/src/lib/Table.svelte
+++ b/packages/table/src/lib/Table.svelte
@@ -14,6 +14,7 @@
   import { Context } from "./context/context.svelte";
   import { CoordinatorContext } from "./context/coordinator.svelte";
   import { CustomCellsContext } from "./context/custom-cells.svelte";
+  import { CustomHeadersContext } from "./context/custom-headers.svelte";
   import { StyleContext } from "./context/style.svelte";
   import { OID } from "./mosaic-clients/RowsClient.js";
   import { add, diff, remove } from "./util.js";
@@ -35,6 +36,7 @@
     lineHeight,
     numLines,
     customCells,
+    additionalHeaderContents,
     headerHeight,
     onRowClick,
     highlightedRows,
@@ -155,6 +157,14 @@
       CustomCellsContext.config = customCells;
     } else {
       CustomCellsContext.config = {};
+    }
+  });
+
+  $effect(() => {
+    if (additionalHeaderContents != null) {
+      CustomHeadersContext.config = additionalHeaderContents;
+    } else {
+      CustomHeadersContext.config = {};
     }
   });
 

--- a/packages/table/src/lib/api/custom-headers.ts
+++ b/packages/table/src/lib/api/custom-headers.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+import type { Component } from "svelte";
+import { createClassComponent } from "svelte/legacy";
+
+export type AdditionalHeaderContentsConfig = { [col: string]: AdditionalHeaderContent };
+
+export interface AdditionalHeaderContentProps {
+  column: string;
+}
+
+type AdditionalHeaderContentClass = new (
+  node: HTMLElement,
+  props: AdditionalHeaderContentProps,
+) => { update?: (props: AdditionalHeaderContentProps) => void; destroy?: () => void };
+
+export type AdditionalHeaderContent =
+  | {
+      class: AdditionalHeaderContentClass;
+      props?: AdditionalHeaderContentProps;
+    }
+  | AdditionalHeaderContentClass;
+
+export function createAdditionalHeaderContentClass<Props extends AdditionalHeaderContentProps>(
+  Component: Component<Props>,
+): any {
+  return class {
+    private component: any;
+
+    constructor(target: HTMLDivElement, props: Props) {
+      this.component = createClassComponent({ component: Component, target: target, props: props });
+    }
+
+    update(props: Partial<Props>) {
+      this.component.$set(props);
+    }
+
+    destroy() {
+      this.component.$destroy();
+    }
+  };
+}

--- a/packages/table/src/lib/context/custom-headers.svelte.ts
+++ b/packages/table/src/lib/context/custom-headers.svelte.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+import { getContext, setContext } from "svelte";
+import type { AdditionalHeaderContentsConfig } from "../api/custom-headers";
+
+export class CustomHeadersState {
+  config: AdditionalHeaderContentsConfig = $state({});
+}
+
+const CUSTOM_HEADERS_KEY = "custom-cells";
+
+export class CustomHeadersContext {
+  public static initialize() {
+    setContext(CUSTOM_HEADERS_KEY, new CustomHeadersState());
+  }
+
+  public static set config(value: AdditionalHeaderContentsConfig) {
+    const CustomHeadersState: CustomHeadersState = getContext(CUSTOM_HEADERS_KEY);
+    CustomHeadersState.config = value;
+  }
+
+  public static get config(): AdditionalHeaderContentsConfig {
+    const customHeadersState: CustomHeadersState = getContext(CUSTOM_HEADERS_KEY);
+    return customHeadersState.config;
+  }
+}

--- a/packages/table/src/lib/index.ts
+++ b/packages/table/src/lib/index.ts
@@ -6,6 +6,7 @@ import { createClassComponent } from "svelte/legacy";
 import Component from "./Table.svelte";
 
 import type { CustomCell, CustomCellsConfig } from "./api/custom-cells";
+import type { AdditionalHeaderContent, AdditionalHeaderContentsConfig } from "./api/custom-headers";
 import type { Theme } from "./api/style";
 import type { ColumnConfigChangeCallback, ColumnConfigs, RowClickCallback } from "./context/config.svelte";
 
@@ -25,6 +26,7 @@ export interface TableProps {
   lineHeight?: number | null;
   numLines?: number | null;
   customCells?: CustomCellsConfig | null;
+  additionalHeaderContents?: AdditionalHeaderContentsConfig | null;
   headerHeight?: number | null;
   onRowClick?: RowClickCallback | null;
   highlightedRows?: any[] | null;
@@ -56,4 +58,4 @@ export class Table {
   }
 }
 
-export type { CustomCell };
+export type { CustomCell, AdditionalHeaderContent as CustomHeader };

--- a/packages/table/src/lib/views/headers/CustomHeaderContents.svelte
+++ b/packages/table/src/lib/views/headers/CustomHeaderContents.svelte
@@ -1,0 +1,41 @@
+<!-- Copyright (c) 2025 Apple Inc. Licensed under MIT License. -->
+<script lang="ts">
+  import type { AdditionalHeaderContent, AdditionalHeaderContentProps } from "../../api/custom-headers";
+  import { Context } from "../../context/context.svelte";
+
+  interface Props {
+    col: string;
+    customHeader: AdditionalHeaderContent;
+  }
+
+  let { col, customHeader }: Props = $props();
+
+  const model = Context.model;
+
+  const customCellAction = (component: AdditionalHeaderContent) => {
+    if (typeof component == "function") {
+      return (node: HTMLDivElement, props: AdditionalHeaderContentProps) => {
+        let obj = new component(node, props);
+        return {
+          ...(obj.update ? { update: obj.update.bind(obj) } : {}),
+          ...(obj.destroy ? { destroy: obj.destroy.bind(obj) } : {}),
+        };
+      };
+    } else {
+      return (node: HTMLDivElement, props: AdditionalHeaderContentProps) => {
+        let obj = new component.class(node, props);
+        return {
+          ...(obj.update ? { update: obj.update.bind(obj) } : {}),
+          ...(obj.destroy ? { destroy: obj.destroy.bind(obj) } : {}),
+        };
+      };
+    }
+  };
+
+  let action = $derived(customCellAction(customHeader));
+</script>
+
+<div use:action={{ column: col }}></div>
+
+<style>
+</style>

--- a/packages/table/src/lib/views/headers/Header.svelte
+++ b/packages/table/src/lib/views/headers/Header.svelte
@@ -68,10 +68,10 @@
     align-items: end;
 
     width: var(--width);
-    height: var(--height);
+    min-height: var(--height);
     flex-shrink: 0;
     box-sizing: border-box;
-    padding: 0.25rem;
+    padding: 0.25em;
     padding-right: calc(calc(var(--padding-x) / 2) + var(--extra-padding-right));
     padding-left: calc(calc(var(--padding-x) / 2) + var(--extra-padding-left));
 
@@ -82,7 +82,6 @@
 
   .header-cell.number {
     justify-content: end;
-    /* flex-direction: row-reverse; */
   }
 
   .header-content {
@@ -92,6 +91,8 @@
   }
 
   .header-title {
+    height: 1.5em;
+    align-items: center;
     display: flex;
     flex-direction: row;
     flex-shrink: 0;

--- a/packages/table/src/lib/views/headers/Header.svelte
+++ b/packages/table/src/lib/views/headers/Header.svelte
@@ -6,7 +6,9 @@
 
   import { ConfigContext } from "../../context/config.svelte";
   import { Context } from "../../context/context.svelte";
+  import { CustomHeadersContext } from "../../context/custom-headers.svelte";
   import { OID } from "../../model/TableModel.svelte.js";
+  import CustomHeaderContents from "./CustomHeaderContents.svelte";
 
   interface Props {
     col: string;
@@ -17,6 +19,7 @@
   const model = Context.model;
   const schema = Context.schema;
   const config = ConfigContext.config;
+  const customHeadersConfig = CustomHeadersContext.config;
 
   let element: HTMLElement | null = $state(null);
   let contentWidth: number = $state(0);
@@ -43,12 +46,17 @@
   style:--extra-padding-left={(isFirstCol ? config.firstColLeftPadding : 0) + "px"}
 >
   <div class="header-content" bind:clientWidth={contentWidth}>
-    {#if col !== OID}
-      <HeaderTitle col={col} />
-      <SortButtons col={col} />
-    {:else}
-      <RowNumberTitle />
+    {#if customHeadersConfig[col]}
+      <CustomHeaderContents col={col} customHeader={customHeadersConfig[col]} />
     {/if}
+    <div class="header-title">
+      {#if col !== OID}
+        <HeaderTitle col={col} />
+        <SortButtons col={col} />
+      {:else}
+        <RowNumberTitle />
+      {/if}
+    </div>
   </div>
 </div>
 
@@ -57,7 +65,7 @@
     position: relative;
     display: flex;
     flex-direction: row;
-    align-items: center;
+    align-items: end;
 
     width: var(--width);
     height: var(--height);
@@ -78,6 +86,12 @@
   }
 
   .header-content {
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+  }
+
+  .header-title {
     display: flex;
     flex-direction: row;
     flex-shrink: 0;

--- a/packages/table/src/lib/views/headers/HeaderRow.svelte
+++ b/packages/table/src/lib/views/headers/HeaderRow.svelte
@@ -100,10 +100,12 @@
     position: absolute;
     z-index: 20;
     left: 0px;
+    box-sizing: border-box;
     height: 100%;
     display: flex;
     flex-direction: row;
-    align-items: center;
+    align-items: end;
+    padding-bottom: 0.25rem;
   }
 
   .column-toggle {

--- a/packages/table/src/lib/views/headers/HeaderRow.svelte
+++ b/packages/table/src/lib/views/headers/HeaderRow.svelte
@@ -45,37 +45,39 @@
 
 <div class="header-row" bind:this={headerElement}>
   <div class="scroll-container" bind:this={scrollContainer}>
-    <div class="dropdown-label-container" bind:this={dropdownLabelContainer}>
-      <Dropdown label="⋮" relativeTo={headerElement}>
-        <ul
-          class="column-toggle"
-          style:--max-height={controller.viewHeight - 48 + "px"}
-          style:--max-width={controller.viewWidth - 48 + "px"}
-        >
-          {#each model.columns as col}
-            <li class="column-entry">
-              <label class="column-label">
-                {col === OID ? "row #" : (config.columnConfigs[col]?.title ?? col)}
-                <input
-                  type="checkbox"
-                  id="{col}-checkbox"
-                  style:float="right"
-                  checked={col === OID ? config.showRowNumber !== false : !config.columnConfigs[col]?.hidden}
-                  onchange={(e) => {
-                    const target = e.target as HTMLInputElement;
-                    const checked = target.checked;
-                    if (checked) {
-                      controller.showColumn(col);
-                    } else {
-                      controller.hideColumn(col);
-                    }
-                  }}
-                />
-              </label>
-            </li>
-          {/each}
-        </ul>
-      </Dropdown>
+    <div class="dropdown-label-container">
+      <div class="dropdown-label" bind:this={dropdownLabelContainer}>
+        <Dropdown label="⋮" relativeTo={headerElement}>
+          <ul
+            class="column-toggle"
+            style:--max-height={controller.viewHeight - 48 + "px"}
+            style:--max-width={controller.viewWidth - 48 + "px"}
+          >
+            {#each model.columns as col}
+              <li class="column-entry">
+                <label class="column-label">
+                  {col === OID ? "row #" : (config.columnConfigs[col]?.title ?? col)}
+                  <input
+                    type="checkbox"
+                    id="{col}-checkbox"
+                    style:float="right"
+                    checked={col === OID ? config.showRowNumber !== false : !config.columnConfigs[col]?.hidden}
+                    onchange={(e) => {
+                      const target = e.target as HTMLInputElement;
+                      const checked = target.checked;
+                      if (checked) {
+                        controller.showColumn(col);
+                      } else {
+                        controller.hideColumn(col);
+                      }
+                    }}
+                  />
+                </label>
+              </li>
+            {/each}
+          </ul>
+        </Dropdown>
+      </div>
     </div>
     {#each columns as col (col)}
       <Header col={col} />
@@ -102,10 +104,16 @@
     left: 0px;
     box-sizing: border-box;
     height: 100%;
+    padding: 0.25em;
     display: flex;
     flex-direction: row;
     align-items: end;
-    padding-bottom: 0.25rem;
+  }
+
+  .dropdown-label {
+    height: 1.5em;
+    align-items: center;
+    display: flex;
   }
 
   .column-toggle {

--- a/packages/table/src/lib/views/headers/Resizer.svelte
+++ b/packages/table/src/lib/views/headers/Resizer.svelte
@@ -36,7 +36,7 @@
     z-index: 2;
     box-sizing: border-box;
     width: 12px;
-    height: calc(100% - 6px);
+    height: calc(100% - 0.25rem);
     margin: 2px;
     cursor: col-resize;
     justify-content: center;
@@ -49,9 +49,11 @@
 
   .pill {
     width: 2px;
-    height: 100%;
+    height: calc(100% - 4px);
+    margin-top: 2px;
+    margin-bottom: 2px;
     background-color: var(--secondary-text-color);
-    opacity: 0.3;
+    opacity: 0.2;
     border-radius: 2px;
   }
 </style>

--- a/packages/table/src/lib/views/headers/Resizer.svelte
+++ b/packages/table/src/lib/views/headers/Resizer.svelte
@@ -49,7 +49,7 @@
 
   .pill {
     width: 2px;
-    height: 80%;
+    height: 100%;
     background-color: var(--secondary-text-color);
     opacity: 0.3;
     border-radius: 2px;

--- a/packages/viewer/src/lib/EmbeddingAtlas.svelte
+++ b/packages/viewer/src/lib/EmbeddingAtlas.svelte
@@ -713,7 +713,6 @@
                     coordinator={coordinator}
                     table={table}
                     rowKey={idColumn}
-                    headerHeight={30}
                     columns={columns.map((x) => x.name)}
                     filter={crossFilter}
                     scrollTo={tableScrollTo}


### PR DESCRIPTION
Originally authored by @haldenl

This adds API for developers to specify additional header content, similar to the CustomCells API. The additional content will be rendered on top of the existing title and sort buttons for its column in the header.

This can be useful for adding custom visualizations or summaries to headers.