### PR TITLE
enable projection from pre-computed vectors

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -47,6 +47,16 @@ embedding-atlas path_to_dataset.parquet --x projection_x --y projection_y
 
 You may use the [SentenceTransformers](https://sbert.net/) package to compute high-dimensional embeddings from text data, and then use the [UMAP](https://umap-learn.readthedocs.io/en/latest/index.html) package to compute 2D projections.
 
+### Using Pre-computed Vectors
+
+If you already have pre-computed embedding vectors (but not the 2D projections), you can specify the column containing the vectors with `--vector`:
+
+```bash
+embedding-atlas path_to_dataset.parquet --vector embedding_vectors
+```
+
+This will apply UMAP dimensionality reduction to your pre-existing vectors without recomputing embeddings. The vectors should be stored as lists or numpy arrays in your dataset.
+
 You may also specify a column for pre-computed nearest neighbors:
 
 ```bash


### PR DESCRIPTION
Hello, Nathan from Notion engineering here, enjoying using embedding-atlas for our use cases so far!

We currently have the vector datasets generated, and want to visualize them easily. This is in support of evaluating various embeddings models without having to re-generate them each time we load the dataset.

The current options are:
- text -> 2D projection end-to-end taken care of
- image -> 2D projection end-to-end taken care of

However, when we have the vectors pre-computed - our only current path is to manually set the x, y, and neighbors columns - which means I need to additional data wrangling before loading it in.

I actually did try this, but I spend quite a bit of time getting things fully working. It would partially work, but things like the nearest neighbor search would not work because there are some internal assumptions about `_row_index` or `__neighbors` that I had to try and re-create.

I'm thinking that embedding-atlas actually already takes care of setting up these columns correctly! So if we pass in a vector field, then let embedding-atlas run UMAP and set the proper columns, it works out of the box.

# Testing
tested locally, happy for suggestions on any additional tests you'd like to see
`python -m embedding_atlas.cli tmp/processed.parquet --vector vector --text span_text`