### PR TITLE
Add batch size parameter to CLI for Sentence Transformers

### DIFF
--- a/packages/backend/embedding_atlas/cli.py
+++ b/packages/backend/embedding_atlas/cli.py
@@ -131,6 +131,12 @@ def find_available_port(start_port: int, max_attempts: int = 10, host="localhost
     help="Allow execution of remote code when loading models from Hugging Face Hub.",
 )
 @click.option(
+    "--batch-size",
+    type=int,
+    default=32,
+    help="Batch size for processing embeddings. Larger values use more memory but may be faster. Smaller values use less memory.",
+)
+@click.option(
     "--x",
     "x_column",
     help="Column containing pre-computed X coordinates for the embedding view.",
@@ -207,6 +213,7 @@ def main(
     enable_projection: bool,
     model: str | None,
     trust_remote_code: bool,
+    batch_size: int,
     x_column: str | None,
     y_column: str | None,
     neighbors_column: str | None,
@@ -280,6 +287,7 @@ def main(
                     neighbors=new_neighbors_column,
                     model=model,
                     trust_remote_code=trust_remote_code,
+                    batch_size=batch_size,
                     umap_args=umap_args,
                 )
             elif image is not None:

--- a/packages/backend/embedding_atlas/cli.py
+++ b/packages/backend/embedding_atlas/cli.py
@@ -133,8 +133,8 @@ def find_available_port(start_port: int, max_attempts: int = 10, host="localhost
 @click.option(
     "--batch-size",
     type=int,
-    default=32,
-    help="Batch size for processing embeddings. Larger values use more memory but may be faster. Smaller values use less memory.",
+    default=None,
+    help="Batch size for processing embeddings (default: 32 for text, 16 for images). Larger values use more memory but may be faster.",
 )
 @click.option(
     "--x",
@@ -213,7 +213,7 @@ def main(
     enable_projection: bool,
     model: str | None,
     trust_remote_code: bool,
-    batch_size: int,
+    batch_size: int | None,
     x_column: str | None,
     y_column: str | None,
     neighbors_column: str | None,
@@ -299,6 +299,7 @@ def main(
                     neighbors=new_neighbors_column,
                     model=model,
                     trust_remote_code=trust_remote_code,
+                    batch_size=batch_size,
                     umap_args=umap_args,
                 )
             else:


### PR DESCRIPTION
Very nice package! For large datasets / when running on powerful GPUs for the embeddings, it would be nice to be able to either raise or lower the batch size for the embedding step. Currently, it's using the ST default of 32. I've had embedding-atlas crash when I run larger embedding models on my local machine, and for these, it would be nice to run with a batch size of 8 or so. 

This PR adds:

- Add --batch-size option to CLI with default value of 32
- Pass batch_size parameter through to compute_text_projection()
- Update _projection_for_texts() to use SentenceTransformer's built-in batch_size parameter
- Include batch_size in cache key for proper caching
- Add documentation for the new parameter

This change shouldn't have an impact on other parts of the frontend, etc, but I mostly looked at the Python part of the code base, so I might have missed something.  