### PR TITLE
fix: window install error

### DIFF
--- a/packages/backend/embedding_atlas/cli.py
+++ b/packages/backend/embedding_atlas/cli.py
@@ -13,7 +13,6 @@ import inquirer
 import numpy as np
 import pandas as pd
 import uvicorn
-import uvloop
 
 from .data_source import DataSource
 from .server import make_server
@@ -346,9 +345,8 @@ def main(
             logging.info(f"Port {port} is not available, using {new_port}")
     else:
         new_port = port
-    uvicorn.run(app, port=new_port, host=host, loop="uvloop", access_log=False)
+    uvicorn.run(app, port=new_port, host=host, access_log=False)
 
 
 if __name__ == "__main__":
-    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
     main()

--- a/packages/backend/pyproject.toml
+++ b/packages/backend/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "sentence-transformers >= 3.3.0",
   "fastapi >= 0.115.0",
   "uvicorn >= 0.32.0",
-  "uvloop >= 0.21.0",
+  'uvloop >= 0.21.0 ; platform_system != "Windows"',
   "pyarrow >= 18.0.0",
   "duckdb >= 1.1.0",
   "inquirer >= 3.0.0",

--- a/packages/backend/start.sh
+++ b/packages/backend/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-uv run embedding-atlas spawn99/wine-reviews --text description --split train --static ../viewer/dist
+uv run embedding-atlas spawn99/wine-reviews --text description --split train --static ../viewer/dist "$@"

--- a/packages/backend/uv.lock
+++ b/packages/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -817,7 +817,7 @@ dependencies = [
     { name = "tqdm" },
     { name = "umap-learn" },
     { name = "uvicorn" },
-    { name = "uvloop" },
+    { name = "uvloop", marker = "sys_platform != 'win32'" },
 ]
 
 [package.dev-dependencies]
@@ -844,7 +844,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.60.0" },
     { name = "umap-learn", specifier = ">=0.5.0" },
     { name = "uvicorn", specifier = ">=0.32.0" },
-    { name = "uvloop", specifier = ">=0.21.0" },
+    { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.21.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Make uvloop conditional on `platform_system != "Windows"`, since it's not available on Windows.

Fix #23.