### PR TITLE
fix: replace crypto.subtle.digest with a simple hash function

### DIFF
--- a/packages/embedding-atlas/src/react.ts
+++ b/packages/embedding-atlas/src/react.ts
@@ -17,8 +17,8 @@ function makeReactWrapper<Props>(
   style: any = { display: "flex" },
 ): (props: Props) => any {
   return (props) => {
-    const container = useRef(null);
-    const component = useRef(null);
+    const container = useRef<any>(null);
+    const component = useRef<any>(null);
     useEffect(() => {
       let c = new ComponentClass(container.current!, props);
       component.current = c;


### PR DESCRIPTION
`crypto.subtle` is not available in non-secure contexts.

Fixes #51