### PR TITLE
chore: exclude sensitive and irrelevant args from text projection hash

### DIFF
--- a/packages/backend/embedding_atlas/projection.py
+++ b/packages/backend/embedding_atlas/projection.py
@@ -197,7 +197,7 @@ def _projection_for_texts(
             "texts": texts,
             "model": model,
             "batch_size": batch_size,
-            **hashed_text_projector_args,
+            "text_projector_args": hashed_text_projector_args,
             "text_projector": text_projector.__name__,
             "umap_args": umap_args,
         }


### PR DESCRIPTION
Currently, arguments passed to the LiteLLM-based text projector such as `api_key`, `api_base` and `sync` invalidate the cache, even though they are not supposed to alter the embeddings returned by the request.

This PR addresses the issue by excluding these args from the hash computation.

Follow-up of #76.