### PR TITLE
chore: update feature flag note

### DIFF
--- a/packages/component/src/lib/embedding_view/EmbeddingViewImpl.svelte
+++ b/packages/component/src/lib/embedding_view/EmbeddingViewImpl.svelte
@@ -384,7 +384,7 @@
       setupWebGPURenderer(canvas);
     } else {
       setupWebGLRenderer(canvas);
-      webGPUPrompt = "WebGPU is unavailable. If you are using Safari, please enable the WebGPU feature flag.";
+      webGPUPrompt = "WebGPU is unavailable. Falling back to WebGL.";
     }
   });
 


### PR DESCRIPTION
Safari 26 now supports WebGPU so we don't need a specific callout for Safari anymore.