### PR TITLE
ci: revert to recommended version tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
           path: dist/
 
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
 


### PR DESCRIPTION
Taken from https://github.com/pypa/gh-action-pypi-publish

Undoes a change in #122 that broke the CI. 