### PR TITLE
fix: typo in line chart description

### DIFF
--- a/packages/viewer/src/charts/chart_types.ts
+++ b/packages/viewer/src/charts/chart_types.ts
@@ -136,7 +136,7 @@ registerChartBuilder({
 
 registerChartBuilder({
   icon: "chart-line",
-  description: "Create a histogram of a field",
+  description: "Create a line chart of two fields",
   ui: [
     { field: { key: "x", label: "X Field", types: ["number", "string"], required: true } }, //
     { field: { key: "y", label: "Y Field", types: ["number"], required: true } }, //


### PR DESCRIPTION
<img width="585" height="335" alt="Screenshot 2026-01-05 at 21 57 48" src="https://github.com/user-attachments/assets/3666804d-fd53-4861-b4ca-13444d39e980" />
