### PR TITLE
fix: visual glitch with downsampled points when points are ordered spatially

### DIFF
--- a/packages/component/src/demo/EmbeddingViewDemo.svelte
+++ b/packages/component/src/demo/EmbeddingViewDemo.svelte
@@ -5,7 +5,9 @@
 
   import EmbeddingView from "../lib/embedding_view/EmbeddingView.svelte";
 
-  let dataset = generateSampleDataset({ numPoints: 5000000, numCategories: 3, numSubClusters: 32 });
+  const numPoints = 2000000;
+
+  let dataset = generateSampleDataset({ numPoints: numPoints, numCategories: 3, numSubClusters: 32 });
   let data = {
     x: new Float32Array(dataset.map((r) => r.x)),
     y: new Float32Array(dataset.map((r) => r.y)),
@@ -19,7 +21,7 @@
   let mode: "points" | "density" = $state.raw("density");
   let colorScheme: "light" | "dark" = $state.raw("light");
   let minimumDensity: number = $state.raw(1 / 16);
-  let downsampleMaxPoints: number | null = $state.raw(4000000);
+  let downsampleMaxPoints: number | null = $state.raw(numPoints);
   let viewportState: ViewportState | null = $state.raw(null);
 
   async function querySelection(x: number, y: number, unitDistance: number): Promise<DataPoint | null> {
@@ -69,7 +71,7 @@
   <label style="display:flex;align-items:center;gap:4px">
     Max Points:
     {#if downsampleMaxPoints != null}
-      <input type="range" bind:value={downsampleMaxPoints} min={50000} max={50000000} step={50000} />
+      <input type="range" bind:value={downsampleMaxPoints} min={5000} max={numPoints} step={5000} />
       {downsampleMaxPoints >= 1000000
         ? (downsampleMaxPoints / 1000000).toFixed(1) + "M"
         : (downsampleMaxPoints / 1000).toFixed(0) + "K"}

--- a/packages/component/src/lib/embedding_view/embedding_view_config.ts
+++ b/packages/component/src/lib/embedding_view/embedding_view_config.ts
@@ -29,9 +29,11 @@ export interface EmbeddingViewConfig {
   /** The stop words for automatic label generation. By default use NLTK stop words. */
   autoLabelStopWords?: string[] | null;
 
-  /** Maximum number of points to render when downsampling is active.
+  /** Approximate maximum number of points to render when downsampling is active.
    * Points are sampled with bias toward sparse regions (fewer points kept in dense areas).
-   * Default: 4000000. Set to null or Infinity to disable downsampling. */
+   * The sampling probability is given by this formula:
+   * P(i) = (downsampleMaxPoints / numPointsInViewport) * (2 / (1 + density(p_i) / maxDensity * downsampleDensityWeight))
+   * Default: 4,000,000. Set to null or Infinity to disable downsampling. */
   downsampleMaxPoints?: number | null;
 
   /** Density weight for downsampling (0-10).

--- a/packages/component/src/lib/renderer_interface.ts
+++ b/packages/component/src/lib/renderer_interface.ts
@@ -33,7 +33,7 @@ export interface EmbeddingRendererProps {
   width: number;
   height: number;
 
-  /** Maximum points to render. null/Infinity = no limit. Default: 4000000 */
+  /** Approximate maximum points to render. null/Infinity = no limit. Default: 4,000,000 */
   downsampleMaxPoints: number | null;
   /** Density weight for downsampling (0-10). Default: 5 */
   downsampleDensityWeight: number;

--- a/packages/component/src/lib/webgpu_renderer/draw_points.ts
+++ b/packages/component/src/lib/webgpu_renderer/draw_points.ts
@@ -64,11 +64,11 @@ export function makeDrawPointsCommand(
 
 /**
  * Draw points using an index buffer for downsampled rendering.
- * Uses points_indexed_vs vertex shader that reads point indices from the index buffer.
+ * Uses points_downsampled_vs vertex shader that reads point indices from the index buffer.
  * Note: Uses group 2 for the vertex shader (read-only index buffer access).
  * Pipeline layout: group 0 (uniforms), group 1 (data buffers), group 2 (index buffer read).
  */
-export function makeDrawPointsIndexedCommand(
+export function makeDrawPointsDownsampledCommand(
   df: Dataflow,
   device: Node<GPUDevice>,
   module: Node<GPUShaderModule>,
@@ -83,7 +83,7 @@ export function makeDrawPointsIndexedCommand(
         layout: device.createPipelineLayout({
           bindGroupLayouts: [layouts.group0, layouts.group1, group5Layout],
         }),
-        vertex: { entryPoint: "points_indexed_vs", module: module },
+        vertex: { entryPoint: "points_downsampled_vs", module: module },
         fragment: {
           entryPoint: "points_fs",
           module: module,

--- a/packages/component/src/lib/webgpu_renderer/program.wgsl
+++ b/packages/component/src/lib/webgpu_renderer/program.wgsl
@@ -61,14 +61,13 @@ struct FragmentOutput {
 // WebGPU has a default limit of 4 bind groups, so we use group 3 (not 4)
 // 3 storage buffers to stay within 8-buffer limit (3 from group1 + 1 from group2 + 3 from group3 = 7)
 @group(3) @binding(0) var<uniform> downsample_uniforms: DownsampleUniforms;
-@group(3) @binding(1) var<storage, read_write> downsample_counters: array<atomic<u32>>; // [visible_count, max_density_fixed, selected_count]
-@group(3) @binding(2) var<storage, read_write> point_data: array<f32>; // density (>0 = visible with density, <=0 = not visible or not accepted)
-@group(3) @binding(3) var<storage, read_write> index_buffer_write: array<u32>; // output indices (compute write)
+@group(3) @binding(1) var<storage, read_write> downsample_counters: array<atomic<u32>>; // [visible_count, max_density_fixed]
+@group(3) @binding(2) var<storage, read_write> point_data: array<f32>; // density (>= 0 means visible with density, < 0 means not visible or not accepted)
 
-// Separate binding for vertex shader in indexed draw pipeline
-// Uses group 2 since the indexed draw pipeline only needs groups 0, 1, 2
+// Separate binding for vertex shader in downsampled draw pipeline
+// Uses group 2 since the pipeline only needs groups 0, 1, 2
 // (read-only access required by WebGPU for vertex shaders)
-@group(2) @binding(0) var<storage, read> index_buffer_read: array<u32>; // output indices (vertex read)
+@group(2) @binding(0) var<storage, read> point_data_read: array<f32>; // same as point_data above
 
 fn get_point(index: u32) -> PointData {
   var result: PointData;
@@ -118,7 +117,9 @@ fn accumulate(@builtin(global_invocation_id) id: vec3<u32>) {
   increment_count(ix + 1, iy + 1, point.category, w4);
 }
 
+// =====================================================
 // Draw Discrete Points
+// =====================================================
 
 struct PointsVertexOutput {
   @builtin(position) position: vec4<f32>,
@@ -154,7 +155,9 @@ fn points_fs(in: PointsVertexOutput) -> FragmentOutput {
   return out;
 }
 
+// =====================================================
 // Draw Density Map
+// =====================================================
 
 struct DrawDensityMapVertexOutput {
   @builtin(position) position: vec4<f32>,
@@ -252,7 +255,9 @@ fn draw_density_map_fs(in: DrawDensityMapVertexOutput) -> FragmentOutput {
   return out;
 }
 
+// =====================================================
 // Gamma Correction
+// =====================================================
 
 struct GammaCorrectionVertexOutput {
   @builtin(position) position: vec4<f32>,
@@ -285,7 +290,9 @@ fn gamma_correction_fs(in: GammaCorrectionVertexOutput) -> @location(0) vec4<f32
   return vec4(rgb, 1.0);
 }
 
+// =====================================================
 // Gaussian Blur
+// =====================================================
 
 @compute @workgroup_size(64, 1)
 fn gaussian_blur_stage_1(@builtin(global_invocation_id) id: vec3<u32>) {
@@ -384,6 +391,7 @@ fn deriche_conv_1d(
 // =====================================================
 // Downsampling: PCG hash for deterministic randomness
 // =====================================================
+
 fn pcg_hash(input: u32) -> u32 {
   var state = input * 747796405u + 2891336453u;
   let word = ((state >> ((state >> 28u) + 4u)) ^ state) * 277803737u;
@@ -399,6 +407,7 @@ fn random_float(seed: u32) -> f32 {
 // =====================================================
 // Uses 2D dispatch for large point counts (>65K workgroups)
 // Stride: 256 workgroups * 256 threads = 65536 threads per row
+
 const DOWNSAMPLE_STRIDE: u32 = 65536u;
 
 @compute @workgroup_size(256)
@@ -431,20 +440,22 @@ fn downsample_viewport_cull(@builtin(global_invocation_id) id: vec3<u32>) {
       density += f32(blur_buffer[offset]);
     }
     // Store density (positive = visible). Add small epsilon to ensure > 0.
-    point_data[index] = max(density, 0.0001);
+    density = min(max(density, 0.0001), 65535.0);
+    point_data[index] = density;
 
     // Track max density using fixed-point atomics
     let density_fixed = u32(density * 65536.0);
     atomicMax(&downsample_counters[1], density_fixed);
   } else {
-    // Not visible: store 0
-    point_data[index] = 0.0;
+    // Not visible: store -1.0
+    point_data[index] = -1.0;
   }
 }
 
 // =====================================================
 // Downsampling Pass 2: Probabilistic acceptance
 // =====================================================
+
 @compute @workgroup_size(256)
 fn downsample_density_sample(@builtin(global_invocation_id) id: vec3<u32>) {
   let index = id.y * DOWNSAMPLE_STRIDE + id.x;
@@ -452,9 +463,9 @@ fn downsample_density_sample(@builtin(global_invocation_id) id: vec3<u32>) {
 
   let density = point_data[index];
 
-  // Not visible (density == 0)
-  if (density <= 0.0) {
-    return; // Already 0, means not accepted
+  // Not visible (density < 0)
+  if (density < 0.0) {
+    return;
   }
 
   let visible_count = atomicLoad(&downsample_counters[0]);
@@ -490,45 +501,31 @@ fn downsample_density_sample(@builtin(global_invocation_id) id: vec3<u32>) {
   if (rand >= final_prob) {
     point_data[index] = -1.0;
   }
-  // If accepted, keep positive value
 }
 
 // =====================================================
-// Downsampling Pass 3: Stream compaction using atomics
+// Draw points with downsampling
 // =====================================================
-// Simplified approach: use atomic counter to assign output indices
-// This works across any number of points without complex prefix sum
-@compute @workgroup_size(256)
-fn downsample_compact(@builtin(global_invocation_id) id: vec3<u32>) {
-  let index = id.y * DOWNSAMPLE_STRIDE + id.x;
-  if (index >= uniforms.count) { return; }
 
-  // point_data > 0 means accepted
-  if (point_data[index] > 0.0) {
-    // Atomically get next output index
-    let output_index = atomicAdd(&downsample_counters[2], 1u);
-    if (output_index < downsample_uniforms.render_limit) {
-      index_buffer_write[output_index] = index;
-    }
-  }
-}
-
-// =====================================================
-// Draw Points with Index Buffer (indexed instancing)
-// =====================================================
 @vertex
-fn points_indexed_vs(
+fn points_downsampled_vs(
   @builtin(instance_index) instance: u32,
   @builtin(vertex_index) part: u32,
 ) -> PointsVertexOutput {
-  let index = index_buffer_read[instance];
+  var out: PointsVertexOutput;
+
+  let point_data = point_data_read[instance];
+  if (point_data < 0.0) {
+    // To discard a point, we set a out-of-viewport position. This avoids fragment costs.
+    out.position = vec4<f32>(-1000, -1000, 0.0, 1.0);
+    return out;
+  }
+
   let framebuffer_size = vec2(f32(uniforms.framebuffer_width), f32(uniforms.framebuffer_height));
   let alpha = uniforms.point_alpha * uniforms.points_alpha;
   let dp = vec2<f32>(f32(part % 2), f32(part / 2)) * 2.0 - 1.0;
-  let point = get_point(index);
+  let point = get_point(instance);
   let pos = uniforms.matrix * point.position;
-
-  var out: PointsVertexOutput;
   out.position = vec4<f32>(pos.xy + dp * uniforms.point_size / framebuffer_size * 2.0, 0.0, 1.0);
   out.dp = vec3(dp, uniforms.point_size);
   out.color = uniforms.category_colors[point.category] * alpha;

--- a/packages/component/src/lib/webgpu_renderer/renderer.ts
+++ b/packages/component/src/lib/webgpu_renderer/renderer.ts
@@ -20,7 +20,7 @@ import { makeAccumulateCommand } from "./accumulate.js";
 import { makeBindGroups } from "./bind_groups.js";
 import { makeDownsampleCommand, makeDownsampleResources, type DownsampleConfig } from "./downsample.js";
 import { makeDrawDensityMapCommand } from "./draw_density_map.js";
-import { makeDrawPointsCommand, makeDrawPointsIndexedCommand } from "./draw_points.js";
+import { makeDrawPointsCommand, makeDrawPointsDownsampledCommand } from "./draw_points.js";
 import { makeGammaCorrectionCommand } from "./gamma_correction.js";
 import { makeGaussianBlurCommand } from "./gaussian_blur.js";
 import { kdeConfig } from "./kde_config.js";
@@ -315,7 +315,7 @@ function makeRenderCommand(
 
   let accumulate = makeAccumulateCommand(df, device, module, bindGroups, dataBuffers, auxiliaryResources);
   let drawPoints = makeDrawPointsCommand(df, device, module, bindGroups, dataBuffers, auxiliaryResources);
-  let drawPointsIndexed = makeDrawPointsIndexedCommand(
+  let drawPointsDownsampled = makeDrawPointsDownsampledCommand(
     df,
     device,
     module,
@@ -368,7 +368,7 @@ function makeRenderCommand(
       inputs.matrix,
       categoryColors,
       drawPoints,
-      drawPointsIndexed,
+      drawPointsDownsampled,
       gammaCorrection,
       accumulate,
       gaussianBlur,
@@ -387,7 +387,7 @@ function makeRenderCommand(
       positionMatrix: Matrix3,
       categoryColors,
       drawPoints,
-      drawPointsIndexed,
+      drawPointsDownsampled,
       gammaCorrection,
       accumulate,
       gaussianBlur,
@@ -442,17 +442,19 @@ function makeRenderCommand(
           gaussianBlur(encoder);
 
           // Run downsampling pipeline with fixed seed for deterministic sampling
-          // Using 0 ensures the same points are always accepted/rejected
+          // Using 42 ensures the same points are always accepted/rejected
           // Viewport culling handles which points are visible
           const downsampleConfig: DownsampleConfig = {
             maxPoints: effectiveMaxPoints!,
             densityWeight: props.downsampleDensityWeight,
-            frameSeed: 0,
+            frameSeed: 42,
           };
-          const sampledCount = downsample(encoder, downsampleConfig);
+
+          // Perform downsample, this fills the point_data buffer.
+          downsample(encoder, downsampleConfig);
 
           // Draw downsampled points
-          drawPointsIndexed(encoder, sampledCount);
+          drawPointsDownsampled(encoder, count);
 
           // If in density mode, also draw density overlay (using all points, already computed)
           if (props.mode == "density") {


### PR DESCRIPTION
- Remove the compactification pass, as it introduces visual glitches and can cause points to be rendered more than once, especially when points are spatially ordered (e.g., sorted by x or Morton order).
- Instead of a compactification pass, we now discard rejected points in the vertex shader with out of view position output.
- Document that the max point count is approximate and the formula for probability.
- The final number of points rendered will now be approximately `render_limit`. It can be either lower or higher, as opposed to only lower in the existing version.