### PR TITLE
feat!: new compute_projection API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
           embedding-atlas --help
 
           python -c "import embedding_atlas"
-          python -c "from embedding_atlas.projection import compute_text_projection, compute_image_projection, compute_vector_projection"
+          python -c "from embedding_atlas.projection import compute_projection"
 
           pip install jupyterlab anywidget
           python -c "from embedding_atlas.widget import EmbeddingAtlasWidget"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,11 @@
 {
   "python.analysis.typeCheckingMode": "standard",
-  "python.defaultInterpreterPath": "packages/backend/.venv/bin/python",
+  "python-envs.pythonProjects": [
+    {
+      "path": "packages/backend",
+      "envManager": "ms-python.python:venv"
+    }
+  ],
   "files.trimTrailingWhitespace": true,
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff",

--- a/packages/backend/embedding_atlas/async_map.py
+++ b/packages/backend/embedding_atlas/async_map.py
@@ -1,0 +1,112 @@
+import asyncio
+import random
+from typing import Awaitable, Callable, TypeVar
+
+from tqdm.auto import tqdm
+
+from .utils import logger
+
+
+class _BackoffState:
+    def __init__(self, base_delay: float, max_delay: float):
+        self.base_delay = base_delay
+        self.max_delay = max_delay
+        self.current_delay = 0.0
+        self.consecutive_errors = 0
+
+    def on_error(self):
+        self.consecutive_errors += 1
+        self.current_delay = min(
+            self.max_delay, self.base_delay * (2 ** (self.consecutive_errors - 1))
+        )
+
+    def on_success(self):
+        self.consecutive_errors = 0
+        self.current_delay = 0.0
+
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+async def async_map(
+    inputs: list[T],
+    func: Callable[[T], Awaitable[R]],
+    *,
+    concurrency: int = 4,
+    max_retry: int = 0,
+    retry_base_delay: float = 1.0,
+    retry_max_delay: float = 30.0,
+    description: str = "Task",
+    fallback: R | None = None,
+) -> list[R]:
+    """
+    Map the inputs by an async function, return a future that resolves to the mapped array (in correct order).
+
+    Args:
+        inputs: List of items to process
+        func: Async function to apply to each item
+        concurrency: Maximum number of concurrent calls
+        max_retry: Maximum number of retry attempts on failure (0 means no retries)
+        retry_base_delay: Base delay in seconds for exponential backoff (default 1.0)
+        retry_max_delay: Maximum delay in seconds for backoff cap (default 30.0)
+        description: Description in the progress bar
+        fallback: When an error happens, fill the given result. If None, raise the error.
+                  When fallback is None and an error occurs, stops processing new tasks immediately.
+    """
+    count = len(inputs)
+    results: list[R | None] = [None] * count
+    semaphore = asyncio.Semaphore(concurrency)
+    backoff = _BackoffState(retry_base_delay, retry_max_delay)
+    # Event to signal that processing should stop (used when fallback is None and an error occurs)
+    stop_event = asyncio.Event()
+    # Store the first error encountered when fallback is None
+    first_error: list[Exception | None] = [None]
+
+    pbar = tqdm(total=count, desc=description)
+
+    async def process(index: int, item: T) -> None:
+        async with semaphore:
+            last_error: Exception | None = None
+            for attempt in range(max_retry + 1):
+                # Check if we should stop before each retry attempt
+                if stop_event.is_set():
+                    return
+
+                try:
+                    # All tasks respect the shared backoff
+                    if backoff.current_delay > 0:
+                        delay = random.uniform(0, backoff.current_delay)
+                        logger.warning(
+                            f"Backoff: waiting {delay:.1f}s before attempt {attempt + 1} for item {index}"
+                        )
+                        await asyncio.sleep(delay)
+                    results[index] = await func(item)
+                    backoff.on_success()
+                    pbar.update(1)
+                    return
+                except Exception as e:
+                    logger.error(e)
+                    backoff.on_error()
+                    last_error = e
+                    if attempt < max_retry:
+                        continue
+            if last_error is not None:
+                if fallback is None:
+                    # Signal other tasks to stop and store the error
+                    if first_error[0] is None:
+                        first_error[0] = last_error
+                    stop_event.set()
+                else:
+                    results[index] = fallback
+                    pbar.update(1)
+
+    await asyncio.gather(*(process(i, item) for i, item in enumerate(inputs)))
+
+    pbar.close()
+
+    # If we stopped due to an error, raise it
+    if first_error[0] is not None:
+        raise first_error[0]
+
+    return results  # type: ignore[return-value]

--- a/packages/backend/embedding_atlas/cache.py
+++ b/packages/backend/embedding_atlas/cache.py
@@ -239,6 +239,67 @@ def file_cache_value(
     return value
 
 
+async def async_file_cache_value(
+    key: Any,
+    value_func: Callable[[], Any],
+    *,
+    scope: str | None = None,
+    cache_root: str | Path | None = None,
+    serializer: Callable[[Any, IO[bytes]], None] | None = None,
+    deserializer: Callable[[IO[bytes]], Any] | None = None,
+    callback: Callable[[Path], None] | None = None,
+):
+    """Async version of ``file_cache_value``.
+
+    Identical behaviour but *value_func* is awaited on a cache miss.
+    """
+    cache_root = _resolve_cache_root(cache_root)
+    if serializer is None:
+        serializer = default_serializer
+    if deserializer is None:
+        deserializer = default_deserializer
+
+    cache_key, encryption_key = _derive_cache_key_and_encryption_key(
+        key, scope, cache_root
+    )
+
+    cache_path = cache_root / cache_key[:2] / cache_key
+
+    if cache_path.exists():
+        try:
+            with open(cache_path, "rb") as file:
+                data = _decrypt_data(file.read(), key=encryption_key)
+
+            result = deserializer(BytesIO(data))
+
+            if callback is not None:
+                callback(cache_path)
+
+            return result
+        except Exception:
+            logger.debug("Cache read failed for key %s", cache_key, exc_info=True)
+
+    value = await value_func()
+
+    try:
+        random_suffix = secrets.token_hex(8)
+        cache_path_tmp = cache_root / cache_key[:2] / f"{cache_key}.tmp-{random_suffix}"
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+        buffer = BytesIO()
+        serializer(value, buffer)
+        encrypted_data = _encrypt_data(buffer.getvalue(), key=encryption_key)
+
+        with open(cache_path_tmp, "wb") as file:
+            file.write(encrypted_data)
+
+        cache_path_tmp.rename(cache_path)
+    except Exception:
+        logger.debug("Cache write failed for key %s", cache_key, exc_info=True)
+
+    return value
+
+
 def _resolve_cache_root(cache_root: str | Path | None = None) -> Path:
     if cache_root is None:
         return (user_cache_path("embedding_atlas") / "cache").resolve()

--- a/packages/backend/embedding_atlas/cli.py
+++ b/packages/backend/embedding_atlas/cli.py
@@ -8,7 +8,6 @@ import logging
 import pathlib
 import socket
 from pathlib import Path
-from typing import Literal
 
 import click
 import inquirer
@@ -150,6 +149,7 @@ def import_modules(names: list[str]):
 @click.argument("inputs", nargs=-1, required=True)
 @click.option("--text", default=None, help="Column containing text data.")
 @click.option("--image", default=None, help="Column containing image data.")
+@click.option("--audio", default=None, help="Column containing audio data.")
 @click.option(
     "--vector", default=None, help="Column containing pre-computed vector embeddings."
 )
@@ -183,10 +183,10 @@ def import_modules(names: list[str]):
     help="Batch size for processing embeddings (default: 32 for text, 16 for images). Larger values use more memory but may be faster.",
 )
 @click.option(
-    "--text-projector",
-    type=click.Choice(["sentence_transformers", "litellm"]),
-    default="sentence_transformers",
-    help="Embedding provider: 'sentence_transformers' (local) or 'litellm' (API-based).",
+    "--embedder",
+    type=str,
+    default=None,
+    help="Embedding backend: 'sentence-transformers' (default for text), 'transformers' (default for image/audio), or 'litellm' (API-based).",
 )
 @click.option(
     "--api-key",
@@ -207,10 +207,10 @@ def import_modules(names: list[str]):
     help="Number of dimensions for output embeddings (litellm only, supported by OpenAI text-embedding-3+).",
 )
 @click.option(
-    "--sync",
-    is_flag=True,
-    default=False,
-    help="Process embeddings synchronously (litellm only). Use for local servers like Ollama to avoid memory issues.",
+    "--max-concurrency",
+    type=int,
+    default=None,
+    help="Maximum number of concurrent embedding batches. Use 1 for local servers like Ollama to avoid memory issues.",
 )
 @click.option(
     "--x",
@@ -337,24 +337,25 @@ def main(
     inputs,
     text: str | None,
     image: str | None,
+    audio: str | None,
     vector: str | None,
     split: list[str] | None,
     enable_projection: bool,
     model: str | None,
     trust_remote_code: bool,
     batch_size: int | None,
-    text_projector: Literal["sentence_transformers", "litellm"],
+    embedder: str | None,
     api_key: str | None,
     api_base: str | None,
     dimensions: int | None,
-    sync: bool,
+    max_concurrency: int | None,
     x_column: str | None,
     y_column: str | None,
     neighbors_column: str | None,
     query: str | None,
     sample: int | None,
     umap_n_neighbors: int | None,
-    umap_min_dist: int | None,
+    umap_min_dist: float | None,
     umap_metric: str | None,
     umap_random_state: int | None,
     static: str | None,
@@ -382,10 +383,12 @@ def main(
 
     if enable_projection and (x_column is None or y_column is None):
         # No x, y column selected, first see if text/image/vectors column is specified, if not, ask for it
-        if text is None and image is None and vector is None:
-            text = prompt_for_column(
+        if text is None and image is None and audio is None and vector is None:
+            selected_column = prompt_for_column(
                 df, "Select a column you want to run the embedding on"
             )
+        else:
+            selected_column = None
         umap_args = {}
         if umap_min_dist is not None:
             umap_args["min_dist"] = umap_min_dist
@@ -396,12 +399,14 @@ def main(
         if umap_metric is not None:
             umap_args["metric"] = umap_metric
         # Run embedding and projection
-        if text is not None or image is not None or vector is not None:
-            from .projection import (
-                compute_image_projection,
-                compute_text_projection,
-                compute_vector_projection,
-            )
+        if (
+            text is not None
+            or image is not None
+            or audio is not None
+            or vector is not None
+            or selected_column is not None
+        ):
+            from .projection import compute_projection
 
             x_column = find_column_name(df.columns, "projection_x")
             y_column = find_column_name(df.columns, "projection_y")
@@ -411,54 +416,51 @@ def main(
             else:
                 # If neighbors_column is already specified, don't overwrite it.
                 new_neighbors_column = None
-            if vector is not None:
-                compute_vector_projection(
-                    df,
-                    vector=vector,
-                    x=x_column,
-                    y=y_column,
-                    neighbors=new_neighbors_column,
-                    umap_args=umap_args,
-                )
-            elif text is not None:
-                # Build kwargs for litellm projector
-                litellm_kwargs = {}
-                if api_key is not None:
-                    litellm_kwargs["api_key"] = api_key
-                if api_base is not None:
-                    litellm_kwargs["api_base"] = api_base
-                if dimensions is not None:
-                    litellm_kwargs["dimensions"] = dimensions
-                if sync:
-                    litellm_kwargs["sync"] = sync
 
-                compute_text_projection(
-                    df,
-                    text=text,
-                    x=x_column,
-                    y=y_column,
-                    neighbors=new_neighbors_column,
-                    model=model,
-                    text_projector=text_projector,
-                    trust_remote_code=trust_remote_code,
-                    batch_size=batch_size,
-                    umap_args=umap_args,
-                    **litellm_kwargs,
-                )
+            # Determine modality and input column
+            if vector is not None:
+                modality = "vector"
+                input_column = vector
             elif image is not None:
-                compute_image_projection(
-                    df,
-                    image=image,
-                    x=x_column,
-                    y=y_column,
-                    neighbors=new_neighbors_column,
-                    model=model,
-                    trust_remote_code=trust_remote_code,
-                    batch_size=batch_size,
-                    umap_args=umap_args,
-                )
+                modality = "image"
+                input_column = image
+            elif audio is not None:
+                modality = "audio"
+                input_column = audio
+            elif text is not None:
+                modality = "text"
+                input_column = text
+            elif selected_column is not None:
+                modality = "auto"
+                input_column = selected_column
             else:
                 raise RuntimeError("unreachable")
+
+            # Build embedder_args from CLI options
+            embedder_args = {}
+            if trust_remote_code:
+                embedder_args["trust_remote_code"] = True
+            if api_key is not None:
+                embedder_args["api_key"] = api_key
+            if api_base is not None:
+                embedder_args["api_base"] = api_base
+            if dimensions is not None:
+                embedder_args["dimensions"] = dimensions
+            # Pass embedder directly; compute_projection handles defaults and validation
+            df = compute_projection(
+                df,
+                inputs=input_column,
+                modality=modality,
+                x=x_column,
+                y=y_column,
+                neighbors=new_neighbors_column,
+                embedder=embedder,
+                model=model,
+                batch_size=batch_size,
+                max_concurrency=max_concurrency,
+                embedder_args=embedder_args or None,
+                umap_args=umap_args or None,
+            )
 
     id_column = find_column_name(df.columns, "__row_index__")
     df[id_column] = range(df.shape[0])

--- a/packages/backend/embedding_atlas/embedding.py
+++ b/packages/backend/embedding_atlas/embedding.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+from collections.abc import Callable
+from io import BytesIO
+from typing import Any
+
+import numpy as np
+
+from .utils import logger
+
+
+def create_embedder(
+    name: str, *, modality: str, model: str | None, embedder_args: dict
+) -> Callable:
+    """Create a built-in embedder function by name."""
+    factories = {
+        "sentence-transformers": _create_sentence_transformers_embedder,
+        "transformers": _create_transformers_embedder,
+        "litellm": _create_litellm_embedder,
+    }
+    if name not in factories:
+        raise ValueError(
+            f"Unknown embedder: {name}. Must be one of: {list(factories.keys())}"
+        )
+    return factories[name](modality=modality, model=model, embedder_args=embedder_args)
+
+
+def _create_sentence_transformers_embedder(
+    *, modality: str, model: str | None, embedder_args: dict
+) -> Callable:
+    """Return an async embedder backed by SentenceTransformers (text only)."""
+    if modality != "text":
+        raise NotImplementedError(
+            "The sentence-transformers embedder only supports text embedding"
+        )
+
+    from sentence_transformers import SentenceTransformer
+
+    model_name = model or "all-MiniLM-L6-v2"
+    default_args = {"trust_remote_code": False}
+    merged = {**default_args, **embedder_args}
+    logger.info("Loading model %s...", model_name)
+    st_model = SentenceTransformer(model_name, **merged)
+
+    async def _embed(
+        batch: list[str], *, model: str | None, embedder_args: dict
+    ) -> np.ndarray:
+        return st_model.encode(batch, show_progress_bar=False, batch_size=len(batch))
+
+    return _embed
+
+
+def _create_transformers_embedder(
+    *, modality: str, model: str | None, embedder_args: dict
+) -> Callable:
+    """Return an async embedder backed by HuggingFace transformers pipelines."""
+    dispatch = {
+        "text": _create_transformers_text_embedder,
+        "image": _create_transformers_image_embedder,
+        "audio": _create_transformers_audio_embedder,
+    }
+    if modality not in dispatch:
+        raise NotImplementedError(
+            f"The transformers embedder does not support {modality} embeddings"
+        )
+    return dispatch[modality](model=model, embedder_args=embedder_args)
+
+
+def _create_transformers_text_embedder(
+    *, model: str | None, embedder_args: dict
+) -> Callable:
+    """Return an async embedder backed by a HuggingFace feature-extraction pipeline."""
+    from transformers import pipeline
+
+    model_name = model or "sentence-transformers/all-MiniLM-L6-v2"
+    logger.info("Loading transformers pipeline for model %s...", model_name)
+    pipe = pipeline("feature-extraction", model=model_name, **embedder_args)
+
+    async def _embed(
+        batch: list[Any], *, model: str | None, embedder_args: dict
+    ) -> np.ndarray:
+        outputs = pipe(batch)
+        embeddings = []
+        for output in outputs:
+            arr = np.array(output)
+            if arr.ndim > 1:
+                arr = arr.mean(axis=tuple(range(arr.ndim - 1)))
+            embeddings.append(arr)
+        return np.stack(embeddings).astype(np.float32)
+
+    return _embed
+
+
+def _create_transformers_image_embedder(
+    *, model: str | None, embedder_args: dict
+) -> Callable:
+    """Return an async embedder backed by a HuggingFace image-feature-extraction pipeline."""
+    from transformers import pipeline
+
+    model_name = model or "google/vit-base-patch16-224"
+    logger.info("Loading transformers pipeline for model %s...", model_name)
+    pipe = pipeline("image-feature-extraction", model=model_name, **embedder_args)
+
+    async def _embed(
+        batch: list[Any], *, model: str | None, embedder_args: dict
+    ) -> np.ndarray:
+        from PIL import Image
+
+        images = [Image.open(BytesIO(item["bytes"])).convert("RGB") for item in batch]
+        outputs = pipe(images)  # type: ignore
+        embeddings = []
+        for output in outputs:
+            arr = np.array(output)
+            if arr.ndim > 1:
+                arr = arr.mean(axis=tuple(range(arr.ndim - 1)))
+            embeddings.append(arr)
+        return np.stack(embeddings).astype(np.float32)
+
+    return _embed
+
+
+def _create_transformers_audio_embedder(
+    *, model: str | None, embedder_args: dict
+) -> Callable:
+    """Return an async embedder backed by CLAP for audio data."""
+    try:
+        import soundfile as sf
+    except ImportError:
+        raise ImportError(
+            "Audio embedding requires the `soundfile` package. "
+            "Please run `pip install soundfile`, then try again."
+        ) from None
+
+    import torch
+    from transformers import ClapModel, ClapProcessor
+
+    model_name = model or "laion/clap-htsat-fused"
+    logger.info("Loading CLAP model %s...", model_name)
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    clap_model = ClapModel.from_pretrained(model_name, **embedder_args).to(device)  # type: ignore
+    clap_processor = ClapProcessor.from_pretrained(model_name)
+
+    target_sr = clap_processor.feature_extractor.sampling_rate  # type: ignore
+
+    async def _embed(
+        batch: list[Any], *, model: str | None, embedder_args: dict
+    ) -> np.ndarray:
+        from scipy.signal import resample
+
+        waveforms = []
+        for item in batch:
+            audio_bytes = item["bytes"]
+            data, sr = sf.read(BytesIO(audio_bytes))
+            # Convert stereo to mono
+            if data.ndim > 1:
+                data = data.mean(axis=1)
+            # Resample to expected rate if needed
+            if sr != target_sr:
+                num_samples = int(len(data) * target_sr / sr)
+                data = resample(data, num_samples)
+            waveforms.append(data)
+
+        inputs = clap_processor(
+            audio=waveforms,
+            sampling_rate=target_sr,  # type: ignore
+            return_tensors="pt",  # type: ignore
+            padding=True,  # type: ignore
+        ).to(device)
+
+        with torch.no_grad():
+            audio_embeds = clap_model.get_audio_features(**inputs)
+
+        if hasattr(audio_embeds, "pooler_output"):
+            audio_embeds = audio_embeds.pooler_output  # type: ignore
+        return audio_embeds.cpu().float().numpy()  # type: ignore
+
+    return _embed
+
+
+def _create_litellm_embedder(
+    *, modality: str, model: str | None, embedder_args: dict
+) -> Callable:
+    """Return an async embedder backed by LiteLLM."""
+
+    if model is None:
+        raise ValueError("model must be specified with the litellm embedder")
+
+    async def _embed(
+        batch: list[Any], *, model: str | None, embedder_args: dict
+    ) -> np.ndarray:
+        from litellm import aembedding
+
+        if model is None:
+            raise ValueError("model must be specified with the litellm embedder")
+
+        if modality == "image":
+            import base64
+
+            embeddings = []
+            for item in batch:
+                b64 = base64.b64encode(item["bytes"]).decode("ascii")
+                response = await aembedding(
+                    input=[f"data:image/png;base64,{b64}"],
+                    model=model,
+                    **embedder_args,
+                )
+                embeddings.append(response.data[0]["embedding"])
+            return np.array(embeddings)
+        else:
+            response = await aembedding(
+                input=batch,
+                model=model,
+                **embedder_args,
+            )
+            return np.array([item["embedding"] for item in response.data])
+
+    return _embed

--- a/packages/backend/embedding_atlas/projection.py
+++ b/packages/backend/embedding_atlas/projection.py
@@ -1,15 +1,336 @@
 # Copyright (c) 2025 Apple Inc. Licensed under MIT License.
 
+import asyncio
+from collections.abc import Callable
 from dataclasses import dataclass
-from io import BytesIO
 from pathlib import Path
-from typing import IO, Callable, Literal
+from typing import IO
 
+import narwhals as nw
 import numpy as np
-import pandas as pd
+from narwhals.typing import IntoDataFrameT
 
-from .cache import file_cache_value
+from .cache import async_file_cache_value
+from .embedding import create_embedder
 from .utils import logger
+
+DEFAULT_MAX_CONCURRENCY = 8
+
+
+def compute_projection(
+    data_frame: IntoDataFrameT,
+    *,
+    inputs: str,
+    modality: str = "auto",
+    x: str = "projection_x",
+    y: str = "projection_y",
+    neighbors: str | None = "neighbors",
+    embedder: str | Callable | None = None,
+    model: str | None = None,
+    batch_size: int | None = None,
+    max_concurrency: int | None = None,
+    embedder_args: dict | None = None,
+    umap_args: dict | None = None,
+    cache_root: str | Path | None = None,
+) -> IntoDataFrameT:
+    """
+    Compute embeddings and generate 2D projections for a DataFrame column.
+
+    This is a unified entry point that auto-detects the modality of the input
+    data (text, image, audio, or vector) and delegates to the appropriate
+    projection function.
+
+    Note: This function cannot be called from within a running async event loop
+    (e.g. Jupyter notebooks). Use ``async_compute_projection`` instead.
+
+    Args:
+        data_frame: DataFrame containing the data to process. Accepts any
+            narwhals-compatible frame (pandas, Polars, cuDF, Modin, etc.).
+        inputs: str, column name containing the data to embed/project.
+        modality: str, the type of data in the inputs column. One of
+            'text', 'image', 'audio', 'vector', or 'auto' (auto-detect).
+        x: str, column name where the UMAP X coordinates will be stored.
+        y: str, column name where the UMAP Y coordinates will be stored.
+        neighbors: str or None, column name where nearest neighbor indices
+            will be stored. Set to None to skip.
+        embedder: the embedding backend to use. Can be:
+            - A string: 'sentence-transformers', 'transformers', or 'litellm'
+              to use a built-in embedder.
+            - An async callable with signature
+              ``async def(batch: list[Any], *, model, embedder_args) -> np.ndarray``
+              to use a custom embedder. The function receives a list of canonical
+              items (strings for text, ``{"bytes": bytes}`` dicts for image/audio)
+              and must return an ndarray of shape ``(batch_size, embedding_dim)``.
+            - None (default): auto-selects 'sentence-transformers' for text,
+              'transformers' for image/audio.
+        model: str or None, name of the embedding model.
+        batch_size: int or None, batch size for processing.
+        max_concurrency: int or None, maximum number of concurrent batches.
+        embedder_args: dict, embedder-specific arguments (e.g., api_key, api_base).
+        umap_args: dict, arguments for the UMAP algorithm.
+        cache_root: str or Path or None, root directory for caching results.
+
+    Returns:
+        A new DataFrame (same type as input) with projection columns added.
+    """
+    return asyncio.run(
+        async_compute_projection(
+            data_frame,
+            inputs=inputs,
+            modality=modality,
+            x=x,
+            y=y,
+            neighbors=neighbors,
+            embedder=embedder,
+            model=model,
+            batch_size=batch_size,
+            max_concurrency=max_concurrency,
+            embedder_args=embedder_args,
+            umap_args=umap_args,
+            cache_root=cache_root,
+        )
+    )
+
+
+async def async_compute_projection(
+    data_frame: IntoDataFrameT,
+    *,
+    inputs: str,
+    modality: str = "auto",
+    x: str = "projection_x",
+    y: str = "projection_y",
+    neighbors: str | None = "neighbors",
+    embedder: str | Callable | None = None,
+    model: str | None = None,
+    batch_size: int | None = None,
+    max_concurrency: int | None = None,
+    embedder_args: dict | None = None,
+    umap_args: dict | None = None,
+    cache_root: str | Path | None = None,
+) -> IntoDataFrameT:
+    """
+    Async version of ``compute_projection``.
+
+    Use this when calling from within a running async event loop (e.g. Jupyter
+    notebooks)::
+
+        df = await async_compute_projection(df, inputs="text")
+
+    See ``compute_projection`` for full argument documentation.
+    """
+    nw_frame = nw.from_native(data_frame, eager_only=True)
+    series = nw_frame[inputs]
+    embedder_args = embedder_args or {}
+    umap_args = umap_args or {}
+
+    # 1. Infer modality
+    if modality == "auto":
+        modality = _infer_modality(series)
+        logger.info("Auto-detected modality: %s", modality)
+
+    # 2. Convert inputs to canonical format
+    if modality == "text":
+        canonical = _to_canonical_text(series)
+    elif modality in ("image", "audio"):
+        canonical = _to_canonical_binary(series)
+    elif modality == "vector":
+        canonical = _to_canonical_vector(series)
+    else:
+        raise ValueError(
+            f"Unknown modality: {modality}. Must be one of: text, image, audio, vector, auto"
+        )
+
+    # 3. Resolve embedder (not needed for vector modality)
+    embedder_max_concurrency: int | None = None
+    if modality == "vector":
+        embedder_name = None
+    else:
+        if callable(embedder):
+            embedder_name = getattr(embedder, "__name__", type(embedder).__name__)
+        else:
+            if embedder is None:
+                embedder = _default_embedder(modality)
+            elif embedder == "sentence_transformers":
+                embedder = "sentence-transformers"
+
+            if embedder in ("sentence-transformers", "transformers"):
+                embedder_max_concurrency = 1
+
+            embedder_name = embedder
+
+    if max_concurrency is None:
+        max_concurrency = DEFAULT_MAX_CONCURRENCY
+    if embedder_max_concurrency is not None:
+        max_concurrency = min(embedder_max_concurrency, max_concurrency)
+
+    cache_key = {
+        "version": 1,
+        "inputs": canonical,
+        "modality": modality,
+        "embedder": embedder_name,
+        "model": model,
+        "umap_args": umap_args,
+        "embedder_args": _caching_embedder_args(embedder_args),
+    }
+
+    async def run() -> Projection:
+        if modality == "vector":
+            embedding = np.array(canonical).astype(np.float32)
+        else:
+            if callable(embedder):
+                embed_fn = embedder
+            elif embedder is not None:
+                embed_fn = create_embedder(
+                    embedder,
+                    modality=modality,
+                    model=model,
+                    embedder_args=embedder_args,
+                )
+            else:
+                raise RuntimeError("unreachable")
+            embedding = await _run_embedding(
+                embed_fn,
+                canonical,
+                model=model,
+                embedder_args=embedder_args,
+                batch_size=batch_size,
+                max_concurrency=max_concurrency,
+            )
+
+        return _run_umap(embedding, umap_args=umap_args)
+
+    proj = await async_file_cache_value(
+        cache_key,
+        run,
+        scope="compute_projection",
+        serializer=Projection.serialize,
+        deserializer=Projection.deserialize,
+        callback=lambda cache_path: print(
+            "Using cached projection from " + str(cache_path)
+        ),
+        cache_root=cache_root,
+    )
+
+    # Create a new data frame with the columns from the original, and add proj columns to it.
+    backend = nw.get_native_namespace(nw_frame)
+    new_columns = [
+        nw.new_series(x, proj.projection[:, 0].tolist(), nw.Float64, backend=backend),
+        nw.new_series(y, proj.projection[:, 1].tolist(), nw.Float64, backend=backend),
+    ]
+    if neighbors is not None:
+        new_columns.append(
+            nw.new_series(
+                neighbors,
+                [
+                    {"distances": b, "ids": a}
+                    for a, b in zip(proj.knn_indices, proj.knn_distances)
+                ],
+                backend=backend,
+            )
+        )
+    return nw.to_native(nw_frame.with_columns(new_columns))
+
+
+def _detect_binary_modality(data: bytes) -> str:
+    """Detect whether binary data is an image or audio based on magic bytes."""
+    # Image formats
+    if data[:8] == b"\x89PNG\r\n\x1a\n":  # PNG
+        return "image"
+    if data[:2] == b"\xff\xd8":  # JPEG
+        return "image"
+    if data[:4] == b"GIF8":  # GIF87a / GIF89a
+        return "image"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":  # WebP
+        return "image"
+    if data[:4] == b"\x00\x00\x01\x00":  # ICO
+        return "image"
+    if data[:2] in (b"BM",):  # BMP
+        return "image"
+    if data[:4] in (b"II\x2a\x00", b"MM\x00\x2a"):  # TIFF
+        return "image"
+
+    # Audio formats
+    if data[:4] == b"RIFF" and data[8:12] == b"WAVE":  # WAV
+        return "audio"
+    if data[:4] == b"fLaC":  # FLAC
+        return "audio"
+    if data[:4] == b"OggS":  # OGG (Vorbis/Opus)
+        return "audio"
+    if data[:3] == b"ID3" or data[:2] == b"\xff\xfb":  # MP3 (ID3 tag or sync frame)
+        return "audio"
+    if len(data) >= 12 and data[4:8] == b"ftyp":  # MP4/M4A container
+        return "audio"
+    if data[:4] == b".snd":  # AU
+        return "audio"
+    if data[:4] in (b"FORM",) and data[8:12] == b"AIFF":  # AIFF
+        return "audio"
+
+    # Default to image for unrecognized binary data
+    return "image"
+
+
+def _infer_modality(series: nw.Series) -> str:
+    """Infer the modality by inspecting the first non-null value in the series."""
+    non_null = series.drop_nulls()
+    if len(non_null) == 0:
+        return "text"
+    sample = non_null[0]
+
+    # Check for vector: list[float] or 1-dimensional ndarray
+    if isinstance(sample, np.ndarray) and sample.ndim == 1:
+        return "vector"
+    if (
+        isinstance(sample, list)
+        and len(sample) > 0
+        and isinstance(sample[0], (int, float))
+    ):
+        return "vector"
+
+    # Check for image/audio: bytes or {"bytes": ...}
+    if isinstance(sample, bytes):
+        return _detect_binary_modality(sample)
+    if isinstance(sample, dict) and "bytes" in sample:
+        raw = sample["bytes"]
+        if isinstance(raw, list):
+            raw = bytes(raw)
+        return _detect_binary_modality(raw)
+
+    # Default to text
+    return "text"
+
+
+def _to_canonical_text(series: nw.Series) -> list[str]:
+    """Convert series to canonical text format: list[str] with nulls as 'null'."""
+    return series.fill_null("null").cast(nw.String).to_list()
+
+
+def _to_canonical_binary(series: nw.Series) -> list[dict]:
+    """Convert series to canonical image format: list[{"bytes": bytes}]."""
+    result = []
+    for value in series.to_list():
+        if isinstance(value, bytes):
+            result.append({"bytes": value})
+        elif isinstance(value, dict) and "bytes" in value:
+            raw = value["bytes"]
+            if isinstance(raw, list):
+                raw = bytes(raw)
+            result.append({"bytes": raw})
+        else:
+            raise ValueError(
+                f"Cannot convert value of type {type(value)} to image/audio format"
+            )
+    return result
+
+
+def _to_canonical_vector(series: nw.Series) -> list[np.ndarray]:
+    """Convert series to canonical vector format: list[ndarray[float32]]."""
+    result = []
+    for value in series.to_list():
+        if isinstance(value, np.ndarray):
+            result.append(value.astype(np.float32))
+        else:
+            result.append(np.array(value, dtype=np.float32))
+    return result
 
 
 @dataclass
@@ -19,14 +340,6 @@ class Projection:
 
     knn_indices: np.ndarray
     knn_distances: np.ndarray
-
-    @staticmethod
-    def exists(path: Path):
-        return (
-            path.with_suffix(".projection.npy").exists()
-            and path.with_suffix(".knn_indices.npy").exists()
-            and path.with_suffix(".knn_distances.npy").exists()
-        )
 
     @staticmethod
     def serialize(value: "Projection", fd: IO[bytes]) -> None:
@@ -44,41 +357,6 @@ class Projection:
             projection=d["projection"],
             knn_indices=d["knn_indices"],
             knn_distances=d["knn_distances"],
-        )
-
-    @staticmethod
-    def save(path: Path, value: "Projection"):
-        np.save(
-            path.with_suffix(".projection.npy"),
-            value.projection,
-            allow_pickle=False,
-        )
-        np.save(
-            path.with_suffix(".knn_indices.npy"),
-            value.knn_indices,
-            allow_pickle=False,
-        )
-        np.save(
-            path.with_suffix(".knn_distances.npy"),
-            value.knn_distances,
-            allow_pickle=False,
-        )
-
-    @staticmethod
-    def load(path: Path) -> "Projection":
-        return Projection(
-            projection=np.load(
-                path.with_suffix(".projection.npy"),
-                allow_pickle=False,
-            ),
-            knn_indices=np.load(
-                path.with_suffix(".knn_indices.npy"),
-                allow_pickle=False,
-            ),
-            knn_distances=np.load(
-                path.with_suffix(".knn_distances.npy"),
-                allow_pickle=False,
-            ),
         )
 
 
@@ -114,451 +392,47 @@ def _run_umap(
     return Projection(projection=result, knn_indices=knn[0], knn_distances=knn[1])
 
 
-# Signature of a function that takes a list of strings, batch size, model name, and optional args, and returns a numpy array of embeddings.
-TextProjectorCallback = Callable[
-    [list[str], int, str, dict | None],
-    np.ndarray,
-]
-
-
-def _project_text_with_sentence_transformers(
-    texts: list[str],
-    batch_size: int,
-    model: str,
-    args: dict | None = None,
+async def _run_embedding(
+    fn: Callable,
+    data: list,
+    *,
+    model: str | None,
+    embedder_args: dict,
+    batch_size: int | None,
+    max_concurrency: int | None,
 ) -> np.ndarray:
-    from sentence_transformers import SentenceTransformer
+    """Run an embedder function over *data* in batches, return concatenated result."""
+    batch_size = batch_size or 32
+    batches = [data[i : i + batch_size] for i in range(0, len(data), batch_size)]
 
-    default_args = {
-        "trust_remote_code": False,
-    }
-    merged_args = {**default_args, **(args or {})}
-
-    logger.info("Loading model %s...", model)
-    transformer = SentenceTransformer(model, **merged_args)
-    return transformer.encode(texts, batch_size=batch_size)
-
-
-def _project_text_with_litellm(
-    texts: list[str],
-    batch_size: int,
-    model: str,
-    args: dict | None = None,
-) -> np.ndarray:
-    from litellm import aembedding, embedding
-
-    default_args = {
-        "sync": False,
-    }
-    merged_args = {**default_args, **(args or {})}
-
-    def run_sync() -> list:
-        # Process batches synchronously
-        return [
-            embedding(
-                input=texts[i : i + batch_size],
-                model=model,
-                **merged_args,
-            )
-            for i in range(0, len(texts), batch_size)
-        ]
-
-    def run_async() -> list:
-        import asyncio
-
-        async def run_async_coro() -> list:
-            # Create coroutines for each batch for asynchronous processing
-            response_coroutines = [
-                aembedding(
-                    input=texts[i : i + batch_size],
-                    model=model,
-                    **merged_args,
-                )
-                for i in range(0, len(texts), batch_size)
-            ]
-
-            return await asyncio.gather(*response_coroutines)
-
-        return asyncio.run(run_async_coro())
-
-    # Determine whether to run synchronously or asynchronously
-    should_run_sync: bool = merged_args["sync"]
-    responses = run_sync() if should_run_sync else run_async()
-
-    # Unnest embeddings from response wrapper objects
-    return np.array(
-        [
-            np.array(item["embedding"])
-            for response in responses
-            for item in response.data
-        ]
+    logger.info(
+        "Running embedding for %d items in %d batches (batch_size=%d)...",
+        len(data),
+        len(batches),
+        batch_size,
     )
 
+    from .async_map import async_map
 
-def _projection_for_texts(
-    texts: list[str],
-    *,
-    model: str | None = None,
-    batch_size: int | None = None,
-    text_projector_args: dict | None = None,
-    text_projector: TextProjectorCallback | None = None,
-    umap_args: dict | None = None,
-) -> Projection:
-    if model is None:
-        model = "all-MiniLM-L6-v2"
-    if text_projector is None:
-        text_projector = _project_text_with_sentence_transformers
+    results = await async_map(
+        batches,
+        lambda b: fn(b, model=model, embedder_args=embedder_args),
+        concurrency=max_concurrency or 1,
+        max_retry=10,
+        description="Embedding",
+    )
+    return np.concatenate(results, axis=0)
 
-    # Set default batch size if not provided
-    if batch_size is None:
-        batch_size = 32
-        logger.info(
-            "Using default batch size of %d for text. Adjust with --batch-size if you encounter memory issues or want to speed up processing.",
-            batch_size,
-        )
 
-    def compute():
-        logger.info(
-            "Running embedding for %d texts with batch size %d using %s...",
-            len(texts),
-            batch_size,
-            text_projector.__name__,
-        )
-        hidden_vectors = text_projector(texts, batch_size, model, text_projector_args)
+def _default_embedder(modality: str):
+    if modality == "text":
+        return "sentence-transformers"
+    else:
+        return "transformers"
 
-        return _run_umap(hidden_vectors, umap_args=umap_args)
 
-    # Some arguments may contain sensitive info (e.g., API keys) or do not invalidate the cache, so we exclude them
-    excluded_text_projector_args = {"api_key", "api_base", "sync"}
-    hashed_text_projector_args = {
-        k: v
-        for k, v in (text_projector_args or {}).items()
-        if k not in excluded_text_projector_args
+def _caching_embedder_args(embedder_args: dict) -> dict:
+    IGNORED_KEYS = ["api_key", "api_base"]
+    return {
+        key: value for key, value in embedder_args.items() if key not in IGNORED_KEYS
     }
-    cache_key = {
-        "version": 2,
-        "texts": texts,
-        "model": model,
-        "batch_size": batch_size,
-        "text_projector_args": hashed_text_projector_args,
-        "text_projector": text_projector.__name__,
-        "umap_args": umap_args,
-    }
-
-    return file_cache_value(
-        cache_key,
-        compute,
-        scope="projection_for_texts",
-        serializer=Projection.serialize,
-        deserializer=Projection.deserialize,
-        callback=lambda cache_path: logger.info(
-            "Using cached projection from " + str(cache_path)
-        ),
-    )
-
-
-def _projection_for_images(
-    images: list,
-    *,
-    model: str | None = None,
-    trust_remote_code: bool = False,
-    batch_size: int | None = None,
-    umap_args: dict | None = None,
-) -> Projection:
-    if model is None:
-        model = "google/vit-base-patch16-384"
-
-    # Set default batch size if not provided
-    if batch_size is None:
-        batch_size = 16
-        logger.info(
-            "Using default batch size of %d for images. Adjust with --batch-size if you encounter memory issues or want to speed up processing.",
-            batch_size,
-        )
-
-    cache_key = {
-        "version": 1,
-        "images": images,
-        "model": model,
-        "batch_size": batch_size,
-        "umap_args": umap_args,
-    }
-
-    def compute():
-        # Import on demand.
-        import torch
-        import tqdm
-        from PIL import Image
-        from transformers import pipeline
-
-        def load_image(value):
-            if isinstance(value, bytes):
-                return Image.open(BytesIO(value)).convert("RGB")
-            elif isinstance(value, dict) and "bytes" in value:
-                return Image.open(BytesIO(value["bytes"])).convert("RGB")
-            else:
-                raise ValueError("invalid image value")
-
-        logger.info("Loading model %s...", model)
-
-        pipe = pipeline(
-            "image-feature-extraction",
-            model=model,
-            device_map="auto",
-            trust_remote_code=trust_remote_code,
-        )
-
-        logger.info(
-            "Running embedding for %d images with batch size %d...",
-            len(images),
-            batch_size,
-        )
-        tensors = []
-
-        current_batch = []
-
-        @torch.no_grad()
-        def process_batch():
-            rs: torch.Tensor = pipe(current_batch, return_tensors=True)  # type: ignore
-            current_batch.clear()
-            for r in rs:
-                if len(r.shape) == 3:
-                    r = r.mean(1)
-                assert len(r.shape) == 2
-                tensors.append(r)
-
-        for image in tqdm.tqdm(images, smoothing=0.1):
-            current_batch.append(load_image(image))
-            if len(current_batch) >= batch_size:
-                process_batch()
-        process_batch()
-
-        hidden_vectors = torch.concat(tensors).to(torch.float32).cpu().numpy()
-        result = _run_umap(hidden_vectors, umap_args=umap_args)
-        return result
-
-    return file_cache_value(
-        cache_key,
-        compute,
-        scope="projection_for_images",
-        serializer=Projection.serialize,
-        deserializer=Projection.deserialize,
-        callback=lambda cache_path: logger.info(
-            "Using cached projection from " + str(cache_path)
-        ),
-    )
-
-
-def _find_text_projector_callback(name: str) -> TextProjectorCallback:
-    projector_map = {
-        "sentence_transformers": _project_text_with_sentence_transformers,
-        "litellm": _project_text_with_litellm,
-    }
-
-    if name in projector_map:
-        return projector_map[name]
-
-    raise ValueError(
-        f"Unknown text projector: {name}. Must be one of: {list(projector_map.keys())}"
-    )
-
-
-def compute_text_projection(
-    data_frame: pd.DataFrame,
-    *,
-    text: str,
-    x: str = "projection_x",
-    y: str = "projection_y",
-    neighbors: str | None = "neighbors",
-    model: str | None = None,
-    batch_size: int | None = None,
-    text_projector: Literal[
-        "sentence_transformers",
-        "litellm",
-    ] = "sentence_transformers",
-    umap_args: dict | None = None,
-    **kwargs,
-):
-    """
-    Compute text embeddings and generate 2D projections using UMAP.
-
-    This function processes text data by creating embeddings and then reducing the
-    dimensionality to 2D coordinates using UMAP for visualization purposes.
-
-    Args:
-        data_frame: pandas DataFrame containing the text data to process.
-        text: str, column name containing the texts to embed.
-        x: str, column name where the UMAP X coordinates will be stored.
-        y: str, column name where the UMAP Y coordinates will be stored.
-        neighbors: str, column name where the nearest neighbor indices will be stored.
-        model: str, name or path of the embedding model to use. The interpretation
-            depends on the text_projector:
-            - For 'sentence_transformers': A SentenceTransformer model name or path.
-              See https://www.sbert.net/docs/sentence_transformer/pretrained_models.html
-            - For 'litellm': A LiteLLM-supported model identifier.
-              See https://docs.litellm.ai/docs/embedding/supported_embedding
-        batch_size: int, batch size for processing embeddings. Larger values use more
-            memory but may be faster. Default is 32. When using 'litellm', note that
-            different providers have different limits on input tokens per request, so
-            batch size should be set accordingly to avoid exceeding API limits.
-        text_projector: str, the embedding provider to use. Options are:
-            - 'sentence_transformers' (default): Computes embeddings locally using the
-              SentenceTransformers library. Requires the sentence-transformers package.
-              This approach runs the model on your local machine and is suitable for
-              privacy-sensitive data or when you want full control over the embedding
-              process.
-            - 'litellm': Computes embeddings remotely using API calls through the LiteLLM
-              library. Requires the litellm package and appropriate API credentials.
-              This approach supports a wide range of cloud-based embedding APIs
-              (OpenAI, Cohere, Azure, etc.) and is useful when you want to leverage
-              remote models without local computational overhead.
-        umap_args: dict, additional keyword arguments to pass to the UMAP algorithm
-            (e.g., n_neighbors, min_dist, metric).
-        **kwargs: Additional configuration options for the embedding provider:
-            - For 'sentence_transformers': Options passed to SentenceTransformer.encode().
-              See https://www.sbert.net/docs/package_reference/sentence_transformer/SentenceTransformer.html#sentence_transformers.SentenceTransformer.encode
-              Common options include 'trust_remote_code', 'normalize_embeddings', etc.
-            - For 'litellm': Options passed to litellm.aembedding().
-              See https://docs.litellm.ai/docs/embedding/supported_embedding#input-params-for-litellmembedding
-              Common options include API keys, timeout settings, custom endpoints, etc.
-              Special option 'sync' (bool, default False): Controls whether embeddings are
-              processed asynchronously or synchronously. By default (False), batches are
-              processed asynchronously, which is ideal for remote APIs like OpenAI, Vertex AI,
-              etc., where the embedding happens on a remote instance and the task is IO-bound.
-              However, when performing embeddings through a locally-running server (e.g., Ollama),
-              setting sync=True can help avoid memory issues by processing batches sequentially.
-
-    Returns:
-        The input DataFrame with added columns for X, Y coordinates and nearest neighbors.
-    """
-    text_series = data_frame[text].astype(str).fillna("")
-    text_projector_callback = _find_text_projector_callback(text_projector)
-
-    proj = _projection_for_texts(
-        list(text_series),
-        model=model,
-        batch_size=batch_size,
-        text_projector_args=kwargs,
-        text_projector=text_projector_callback,
-        umap_args=umap_args,
-    )
-    data_frame[x] = proj.projection[:, 0]
-    data_frame[y] = proj.projection[:, 1]
-    if neighbors is not None:
-        data_frame[neighbors] = [  # type: ignore
-            {"distances": b, "ids": a}  # ID is always the same as the row index.
-            for a, b in zip(proj.knn_indices, proj.knn_distances)
-        ]
-
-
-def compute_vector_projection(
-    data_frame: pd.DataFrame,
-    *,
-    vector: str,
-    x: str = "projection_x",
-    y: str = "projection_y",
-    neighbors: str | None = "neighbors",
-    umap_args: dict | None = None,
-):
-    """
-    Generate 2D projections from pre-existing vector embeddings using UMAP.
-
-    This function takes pre-computed vector embeddings and reduces their dimensionality
-    to 2D coordinates using UMAP for visualization purposes.
-
-    Args:
-        data_frame: pandas DataFrame containing the vector data to process.
-        vector: str, column name containing the pre-computed vector embeddings.
-                Each entry should be a list or numpy array of numbers.
-        x: str, column name where the UMAP X coordinates will be stored.
-        y: str, column name where the UMAP Y coordinates will be stored.
-        neighbors: str, column name where the nearest neighbor indices will be stored.
-        umap_args: dict, additional keyword arguments to pass to the UMAP algorithm
-            (e.g., n_neighbors, min_dist, metric).
-
-    Returns:
-        The input DataFrame with added columns for X, Y coordinates and nearest neighbors.
-    """
-    # Convert vector column to numpy array
-    vector_series = data_frame[vector]
-
-    # Convert each vector entry to numpy array and stack them
-    vector_list = []
-    for vector in vector_series:
-        if isinstance(vector, list):
-            vector_array = np.array(vector)
-        elif isinstance(vector, np.ndarray):
-            vector_array = vector
-        else:
-            # Try to convert to numpy array
-            vector_array = np.array(vector)
-        vector_list.append(vector_array)
-
-    # Stack all vectors into a single numpy array
-    hidden_vectors = np.stack(vector_list)
-
-    # Run UMAP on the pre-existing vectors
-    proj = _run_umap(hidden_vectors, umap_args=umap_args)
-
-    # Add projection results to dataframe
-    data_frame[x] = proj.projection[:, 0]
-    data_frame[y] = proj.projection[:, 1]
-    if neighbors is not None:
-        data_frame[neighbors] = [  # type: ignore
-            {"distances": b, "ids": a}  # ID is always the same as the row index.
-            for a, b in zip(proj.knn_indices, proj.knn_distances)
-        ]
-
-
-def compute_image_projection(
-    data_frame: pd.DataFrame,
-    *,
-    image: str,
-    x: str = "projection_x",
-    y: str = "projection_y",
-    neighbors: str | None = "neighbors",
-    model: str | None = None,
-    trust_remote_code: bool = False,
-    batch_size: int | None = None,
-    umap_args: dict | None = None,
-):
-    """
-    Compute image embeddings and generate 2D projections using UMAP.
-
-    This function processes image data by creating embeddings using a model and
-    then reducing the dimensionality to 2D coordinates using UMAP for
-    visualization purposes.
-
-    Args:
-        data_frame: pandas DataFrame containing the image data to process.
-        image: str, column name containing the images to embed.
-        x: str, column name where the UMAP X coordinates will be stored.
-        y: str, column name where the UMAP Y coordinates will be stored.
-        neighbors: str, column name where the nearest neighbor indices will be stored.
-        model: str, name or path of the model to use for embedding.
-        trust_remote_code: bool, whether to trust and execute remote code when loading
-            the model from HuggingFace Hub. Default is False.
-        batch_size: int, batch size for processing images. Larger values use more
-            memory but may be faster. Default is 16.
-        umap_args: dict, additional keyword arguments to pass to the UMAP algorithm
-            (e.g., n_neighbors, min_dist, metric).
-
-    Returns:
-        The input DataFrame with added columns for X, Y coordinates and nearest neighbors.
-    """
-
-    image_series = data_frame[image]
-    proj = _projection_for_images(
-        list(image_series),
-        model=model,
-        trust_remote_code=trust_remote_code,
-        batch_size=batch_size,
-        umap_args=umap_args,
-    )
-    data_frame[x] = proj.projection[:, 0]
-    data_frame[y] = proj.projection[:, 1]
-    if neighbors is not None:
-        data_frame[neighbors] = [  # type: ignore
-            {"distances": b, "ids": a}  # ID is always the same as the row index.
-            for a, b in zip(proj.knn_indices, proj.knn_distances)
-        ]

--- a/packages/backend/examples/notebook.ipynb
+++ b/packages/backend/examples/notebook.ipynb
@@ -8,7 +8,7 @@
    "outputs": [],
    "source": [
     "from embedding_atlas.widget import EmbeddingAtlasWidget\n",
-    "from embedding_atlas.projection import compute_text_projection\n",
+    "from embedding_atlas.projection import async_compute_projection\n",
     "import pandas as pd\n",
     "from datasets import load_dataset"
    ]
@@ -33,7 +33,8 @@
    "outputs": [],
    "source": [
     "# Compute text embedding and projection of the embedding using Sentence Transformers by default\n",
-    "compute_text_projection(df, text=\"description\", x=\"projection_x\", y=\"projection_y\", neighbors=\"neighbors\")"
+    "# Use async_compute_projection in Jupyter notebooks (which have a running event loop)\n",
+    "df = await async_compute_projection(df, inputs=\"description\", modality=\"text\", x=\"projection_x\", y=\"projection_y\", neighbors=\"neighbors\")"
    ]
   },
   {
@@ -81,18 +82,20 @@
    "outputs": [],
    "source": [
     "# Compute text embedding and projection of the embedding using locally running Ollama API\n",
-    "compute_text_projection(\n",
+    "# For local servers, consider setting max_concurrency to a small number (e.g., 2-4)\n",
+    "# to avoid overwhelming the server. Use 1 for sequential processing.\n",
+    "df = await async_compute_projection(\n",
     "    df,\n",
-    "    text=\"description\",\n",
+    "    inputs=\"description\",\n",
+    "    modality=\"text\",\n",
     "    x=\"projection_x\",\n",
     "    y=\"projection_y\",\n",
     "    neighbors=\"neighbors\",\n",
-    "    text_projector=\"litellm\",\n",
-    "    api_base_url=\"http://localhost:11434\",\n",
+    "    embedder=\"litellm\",\n",
+    "    embedder_args={\"api_base\": \"http://localhost:11434\"},\n",
     "    model=\"ollama/nomic-embed-text\",\n",
     "    batch_size=512,\n",
-    "    # Running batches synchronously to avoid overwhelming the local API\n",
-    "    sync=True,\n",
+    "    max_concurrency=2,\n",
     ")"
    ]
   },
@@ -110,38 +113,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aabe196c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Async processing of batches raises error in environments with an already running event loop, so we must patch the loop\n",
-    "!uv pip install nest-asyncio -q\n",
-    "import nest_asyncio\n",
-    "nest_asyncio.apply()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "6048064a",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Compute text embedding and projection of the embedding using OpenAI API\n",
-    "compute_text_projection(\n",
+    "df = await async_compute_projection(\n",
     "    df,\n",
-    "    text=\"description\",\n",
+    "    inputs=\"description\",\n",
+    "    modality=\"text\",\n",
     "    x=\"projection_x\",\n",
     "    y=\"projection_y\",\n",
     "    neighbors=\"neighbors\",\n",
-    "    text_projector=\"litellm\",\n",
+    "    embedder=\"litellm\",\n",
     "    # Your OpenAI API key. You can omit this and set the OPENAI_API_KEY environment variable instead.\n",
-    "    api_key=\"sk-xxx\",\n",
+    "    embedder_args={\"api_key\": \"sk-xxx\"},\n",
     "    model=\"openai/text-embedding-3-small\",\n",
     "    # OpenAI's limit is 300K input token per request, so batch size should be chosen accordingly given the average `text` item length\n",
     "    batch_size=1024,\n",
-    "    # Since calling a remote API is I/O-bound, we can benefit from async processing. This is the default behavior.\n",
-    "    sync=False,\n",
     ")"
    ]
   },
@@ -155,11 +144,19 @@
     "# Display the dataset with the Embedding Atlas widget using text-embedding-3-small embeddings served by OpenAI API\n",
     "EmbeddingAtlasWidget(df, text=\"description\", x=\"projection_x\", y=\"projection_y\", neighbors=\"neighbors\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ee5ab1a-d90c-4f45-b89c-91c2b16bb420",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "embedding-atlas",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -173,7 +170,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/packages/backend/examples/streamlit.py
+++ b/packages/backend/examples/streamlit.py
@@ -2,7 +2,7 @@ import duckdb
 import pandas as pd
 import streamlit as st
 from datasets import load_dataset
-from embedding_atlas.projection import compute_text_projection
+from embedding_atlas.projection import compute_projection
 from embedding_atlas.streamlit import embedding_atlas
 
 
@@ -23,9 +23,10 @@ def main():
     df = load_data()
 
     # Compute text embedding and projection of the embedding
-    compute_text_projection(
+    df = compute_projection(
         df,
-        text="description",
+        inputs="description",
+        modality="text",
         x="projection_x",
         y="projection_y",
         neighbors="neighbors",
@@ -43,9 +44,10 @@ def main():
 
     # Show selected rows in a Streamlit data frame
     st.write("Selected rows:")
-    if value is not None and value.get("predicate") is not None:
+    predicate = value.get("predicate")
+    if value is not None and predicate is not None:
         subset = duckdb.query_df(
-            df, "dataframe", "SELECT * FROM dataframe WHERE " + value.get("predicate")
+            df, "dataframe", "SELECT * FROM dataframe WHERE " + predicate
         )
         st.dataframe(subset)
     else:

--- a/packages/backend/pyproject.toml
+++ b/packages/backend/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "litellm >= 1.70.0, != 1.82.7, != 1.82.8", # Critical supply chain attack: https://futuresearch.ai/blog/litellm-pypi-supply-chain-attack/
   "websockets >= 15.0.1",
   "cryptography >= 35.0.0",
+  "narwhals >= 2.0.0",
 ]
 
 [project.scripts]
@@ -53,6 +54,11 @@ artifacts = [
 [tool.hatch.build.targets.wheel]
 packages = ["embedding_atlas"]
 
+[tool.pytest.ini_options]
+markers = [
+  "external: tests requiring external resources such as models or APIs (skipped unless --run-external is passed)",
+]
+
 [dependency-groups]
 dev = [
   "datasets >= 3.1.0",
@@ -61,4 +67,8 @@ dev = [
   "anywidget >= 0.9.0",
   "docutils >= 0.22.0",
   "pytest >= 9.0.2",
+  "pytest-asyncio>=1.3.0",
+  "pyright >= 1.1.0",
+  "soundfile >= 0.12.0",
+  "polars >= 1.0.0",
 ]

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-external",
+        action="store_true",
+        default=False,
+        help="Run tests that require external resources (models, APIs).",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-external"):
+        return
+    skip = pytest.mark.skip(reason="needs --run-external to run")
+    for item in items:
+        if "external" in item.keywords:
+            item.add_marker(skip)

--- a/packages/backend/tests/test_async_map.py
+++ b/packages/backend/tests/test_async_map.py
@@ -1,0 +1,324 @@
+import asyncio
+
+import pytest
+from embedding_atlas.async_map import async_map
+
+
+class TestAsyncMap:
+    """Tests for the async_map function."""
+
+    @pytest.mark.asyncio
+    async def test_basic_mapping(self):
+        """Test basic async mapping with a simple function."""
+        inputs = [1, 2, 3, 4, 5]
+
+        async def double(x: int) -> int:
+            return x * 2
+
+        results = await async_map(inputs, double, description="Doubling")
+        assert results == [2, 4, 6, 8, 10]
+
+    @pytest.mark.asyncio
+    async def test_empty_input(self):
+        """Test async_map with empty input list."""
+        inputs: list[int] = []
+
+        async def double(x: int) -> int:
+            return x * 2
+
+        results = await async_map(inputs, double, description="Empty")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_preserves_order(self):
+        """Test that results are returned in the correct order despite async execution."""
+        inputs = [5, 1, 3, 2, 4]
+
+        async def delayed_identity(x: int) -> int:
+            # Shorter delays complete first, but order should be preserved
+            await asyncio.sleep(x * 0.001)
+            return x
+
+        results = await async_map(
+            inputs, delayed_identity, concurrency=5, description="Order test"
+        )
+        assert results == [5, 1, 3, 2, 4]
+
+    @pytest.mark.asyncio
+    async def test_concurrency_limit(self):
+        """Test that concurrency limit is respected."""
+        concurrent_count = 0
+        max_concurrent = 0
+
+        async def track_concurrency(x: int) -> int:
+            nonlocal concurrent_count, max_concurrent
+            concurrent_count += 1
+            max_concurrent = max(max_concurrent, concurrent_count)
+            await asyncio.sleep(0.01)
+            concurrent_count -= 1
+            return x
+
+        inputs = list(range(10))
+        await async_map(
+            inputs, track_concurrency, concurrency=3, description="Concurrency test"
+        )
+
+        assert max_concurrent <= 3
+
+    @pytest.mark.asyncio
+    async def test_retry_on_failure(self):
+        """Test that retries work when function fails."""
+        attempt_counts: dict[int, int] = {}
+
+        async def fail_twice(x: int) -> int:
+            attempt_counts[x] = attempt_counts.get(x, 0) + 1
+            if attempt_counts[x] <= 2:
+                raise ValueError(f"Attempt {attempt_counts[x]} for {x}")
+            return x * 2
+
+        inputs = [1, 2, 3]
+        results = await async_map(
+            inputs,
+            fail_twice,
+            max_retry=3,
+            retry_base_delay=0,
+            description="Retry test",
+        )
+
+        assert results == [2, 4, 6]
+        # Each item should have been attempted 3 times (2 failures + 1 success)
+        for x in inputs:
+            assert attempt_counts[x] == 3
+
+    @pytest.mark.asyncio
+    async def test_no_retry_raises_immediately(self):
+        """Test that without retries, errors are raised immediately."""
+
+        async def always_fail(x: int) -> int:
+            raise ValueError(f"Failed for {x}")
+
+        inputs = [1, 2, 3]
+        with pytest.raises(ValueError, match="Failed for"):
+            await async_map(
+                inputs, always_fail, max_retry=0, description="No retry test"
+            )
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_error(self):
+        """Test that fallback value is used when function fails and fallback is provided."""
+
+        async def fail_on_even(x: int) -> int:
+            if x % 2 == 0:
+                raise ValueError(f"Even number: {x}")
+            return x * 2
+
+        inputs = [1, 2, 3, 4, 5]
+        results = await async_map(
+            inputs,
+            fail_on_even,
+            fallback=-1,
+            retry_base_delay=0,
+            description="Fallback test",
+        )
+
+        assert results == [2, -1, 6, -1, 10]
+
+    @pytest.mark.asyncio
+    async def test_fallback_with_retry(self):
+        """Test that fallback is used after all retries are exhausted."""
+        attempt_counts: dict[int, int] = {}
+
+        async def always_fail(x: int) -> int:
+            attempt_counts[x] = attempt_counts.get(x, 0) + 1
+            raise ValueError(f"Always fails for {x}")
+
+        inputs = [1, 2]
+        results = await async_map(
+            inputs,
+            always_fail,
+            max_retry=2,
+            retry_base_delay=0,
+            fallback=0,
+            description="Fallback retry test",
+        )
+
+        assert results == [0, 0]
+        # Each item should have been attempted 3 times (initial + 2 retries)
+        for x in inputs:
+            assert attempt_counts[x] == 3
+
+    @pytest.mark.asyncio
+    async def test_string_inputs(self):
+        """Test async_map with string inputs."""
+        inputs = ["hello", "world", "test"]
+
+        async def uppercase(s: str) -> str:
+            return s.upper()
+
+        results = await async_map(inputs, uppercase, description="Uppercase")
+        assert results == ["HELLO", "WORLD", "TEST"]
+
+    @pytest.mark.asyncio
+    async def test_different_return_type(self):
+        """Test async_map where return type differs from input type."""
+        inputs = [1, 2, 3]
+
+        async def to_string(x: int) -> str:
+            return f"num_{x}"
+
+        results = await async_map(inputs, to_string, description="To string")
+        assert results == ["num_1", "num_2", "num_3"]
+
+    @pytest.mark.asyncio
+    async def test_stops_early_on_error_without_fallback(self):
+        """Test that processing stops early when an error occurs and fallback is None."""
+        processed_items: list[int] = []
+        started_items: list[int] = []
+
+        async def slow_fail_on_first(x: int) -> int:
+            started_items.append(x)
+            if x == 1:
+                # First item fails immediately
+                raise ValueError(f"Failed for {x}")
+            # Other items take longer to process
+            await asyncio.sleep(0.02)
+            processed_items.append(x)
+            return x * 2
+
+        # Use many inputs with low concurrency to ensure some haven't started yet
+        inputs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        with pytest.raises(ValueError, match="Failed for 1"):
+            await async_map(
+                inputs,
+                slow_fail_on_first,
+                concurrency=2,
+                description="Early stop test",
+            )
+
+        # Not all items should have been processed since we stopped early
+        # With concurrency=2, items 1 and 2 start first. Item 1 fails immediately,
+        # which should prevent most other items from being fully processed.
+        assert (
+            len(processed_items) < len(inputs) - 1
+        )  # At least some items were skipped
+
+    @pytest.mark.asyncio
+    async def test_does_not_stop_early_with_fallback(self):
+        """Test that processing continues when fallback is provided even on errors."""
+        processed_items: list[int] = []
+
+        async def fail_on_even(x: int) -> int:
+            await asyncio.sleep(0.001)
+            if x % 2 == 0:
+                raise ValueError(f"Even number: {x}")
+            processed_items.append(x)
+            return x * 2
+
+        inputs = [1, 2, 3, 4, 5]
+        results = await async_map(
+            inputs,
+            fail_on_even,
+            fallback=-1,
+            concurrency=2,
+            description="Continue with fallback test",
+        )
+
+        # All odd items should have been processed
+        assert sorted(processed_items) == [1, 3, 5]
+        # Results should include fallback for even numbers
+        assert results == [2, -1, 6, -1, 10]
+
+    @pytest.mark.asyncio
+    async def test_backoff_slows_down_after_errors(self):
+        """Test that errors cause subsequent calls to be delayed via shared backoff."""
+        call_times: list[float] = []
+        attempt_counts: dict[int, int] = {}
+
+        async def fail_then_succeed(x: int) -> int:
+            attempt_counts[x] = attempt_counts.get(x, 0) + 1
+            call_times.append(asyncio.get_event_loop().time())
+            if x == 0 and attempt_counts[x] <= 2:
+                raise ValueError("transient error")
+            return x
+
+        # Item 0 fails twice then succeeds, items 1-2 should be delayed by the shared backoff.
+        # Use concurrency=1 so calls are sequential and timing is deterministic.
+        start = asyncio.get_event_loop().time()
+        results = await async_map(
+            [0, 0, 0],
+            fail_then_succeed,
+            concurrency=1,
+            max_retry=3,
+            retry_base_delay=0.05,
+            retry_max_delay=1.0,
+            description="Backoff test",
+        )
+
+        elapsed = asyncio.get_event_loop().time() - start
+        assert results == [0, 0, 0]
+        # Two failures with base_delay=0.05 means delays of up to 0.05s and 0.1s.
+        assert elapsed > 0.02, "Expected some backoff delay"
+
+    @pytest.mark.asyncio
+    async def test_backoff_resets_on_success(self):
+        """Test that a successful call resets the shared backoff so later calls aren't delayed."""
+        attempt_counts: dict[int, int] = {}
+
+        async def fail_first_attempt(x: int) -> int:
+            attempt_counts[x] = attempt_counts.get(x, 0) + 1
+            if x == 0 and attempt_counts[x] == 1:
+                raise ValueError("one-time error")
+            return x
+
+        # Item 0 fails once then succeeds (resetting backoff), items 1-4 should not be delayed.
+        # Use concurrency=1 for sequential execution.
+        start = asyncio.get_event_loop().time()
+        results = await async_map(
+            [0, 1, 2, 3, 4],
+            fail_first_attempt,
+            concurrency=1,
+            max_retry=1,
+            retry_base_delay=0.1,
+            retry_max_delay=1.0,
+            description="Backoff reset test",
+        )
+
+        elapsed = asyncio.get_event_loop().time() - start
+        assert results == [0, 1, 2, 3, 4]
+        # If backoff didn't reset, items 1-4 would each wait ~0.1s (total ~0.4s+).
+        # With reset, only item 0's retry has a delay.
+        assert elapsed < 0.5, "Backoff should have reset after success"
+
+    @pytest.mark.asyncio
+    async def test_backoff_affects_concurrent_tasks(self):
+        """Test that backoff from one task's failure delays other concurrent tasks."""
+        call_times: dict[int, list[float]] = {}
+
+        async def fail_item_0(x: int) -> int:
+            t = asyncio.get_event_loop().time()
+            call_times.setdefault(x, []).append(t)
+            if x == 0:
+                raise ValueError("always fails")
+            # Item 1 takes a moment so item 0 fails first
+            await asyncio.sleep(0.01)
+            return x
+
+        # Item 0 always fails (with fallback so processing continues).
+        # Item 1 should be delayed on its second invocation due to shared backoff from item 0's failure.
+        results = await async_map(
+            [0, 0, 1, 1],
+            fail_item_0,
+            concurrency=4,
+            max_retry=0,
+            retry_base_delay=0.05,
+            retry_max_delay=1.0,
+            fallback=-1,
+            description="Shared backoff test",
+        )
+
+        assert results[2] == 1 or results[2] == -1  # item at index 2 has input 1
+        # The key assertion: later calls should have been delayed.
+        # With 4 concurrent tasks and backoff, total time should exceed just the sleep time.
+        all_times = [t for times in call_times.values() for t in times]
+        spread = max(all_times) - min(all_times)
+        assert spread > 0.01, "Expected backoff to spread out call times"

--- a/packages/backend/tests/test_cache.py
+++ b/packages/backend/tests/test_cache.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from embedding_atlas.cache import (
+    async_file_cache_value,
     file_cache_get,
     file_cache_set,
     file_cache_value,
@@ -187,3 +188,59 @@ def test_cache_files_are_encrypted(cache_dir):
     assert len(data_files) == 1
     raw = data_files[0].read_bytes()
     assert b"secret_value" not in raw
+
+
+# ---------------------------------------------------------------------------
+# file_cache_value_async
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_file_cache_value_async_miss(cache_dir):
+    calls = []
+
+    async def compute():
+        calls.append(1)
+        return "computed"
+
+    result = await async_file_cache_value("k", compute, cache_root=cache_dir)
+    assert result == "computed"
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_file_cache_value_async_hit(cache_dir):
+    file_cache_set("k", "cached", cache_root=cache_dir)
+    calls = []
+
+    async def compute():
+        calls.append(1)
+        return "computed"
+
+    result = await async_file_cache_value("k", compute, cache_root=cache_dir)
+    assert result == "cached"
+    assert len(calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_file_cache_value_async_populates_cache(cache_dir):
+    async def compute():
+        return [1, 2, 3]
+
+    await async_file_cache_value("k", compute, cache_root=cache_dir)
+    assert file_cache_get("k", cache_root=cache_dir) == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_file_cache_value_async_callback(cache_dir):
+    file_cache_set("k", "cached", cache_root=cache_dir)
+    paths = []
+
+    async def compute():
+        return "x"
+
+    result = await async_file_cache_value(
+        "k", compute, cache_root=cache_dir, callback=lambda p: paths.append(p)
+    )
+    assert result == "cached"
+    assert len(paths) == 1

--- a/packages/backend/tests/test_modality_detection.py
+++ b/packages/backend/tests/test_modality_detection.py
@@ -1,0 +1,270 @@
+# Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+"""Unit tests for modality detection and canonical conversion helpers."""
+
+import narwhals as nw
+import numpy as np
+import pandas as pd
+import pytest
+from embedding_atlas.projection import (
+    _detect_binary_modality,
+    _infer_modality,
+    _to_canonical_binary,
+    _to_canonical_text,
+    _to_canonical_vector,
+)
+
+
+def _nw_series(values):
+    """Create a narwhals Series from a list of values via pandas."""
+    return nw.from_native(pd.Series(values), series_only=True)
+
+
+# ---------------------------------------------------------------------------
+# _detect_binary_modality
+# ---------------------------------------------------------------------------
+
+
+class TestDetectBinaryModality:
+    # -- Image formats --
+
+    def test_png(self):
+        data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 20
+        assert _detect_binary_modality(data) == "image"
+
+    def test_jpeg(self):
+        data = b"\xff\xd8\xff\xe0" + b"\x00" * 20
+        assert _detect_binary_modality(data) == "image"
+
+    def test_gif87a(self):
+        data = b"GIF87a" + b"\x00" * 20
+        assert _detect_binary_modality(data) == "image"
+
+    def test_gif89a(self):
+        data = b"GIF89a" + b"\x00" * 20
+        assert _detect_binary_modality(data) == "image"
+
+    def test_webp(self):
+        data = b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 20
+        assert _detect_binary_modality(data) == "image"
+
+    def test_ico(self):
+        data = b"\x00\x00\x01\x00" + b"\x00" * 20
+        assert _detect_binary_modality(data) == "image"
+
+    def test_bmp(self):
+        data = b"BM" + b"\x00" * 20
+        assert _detect_binary_modality(data) == "image"
+
+    def test_tiff_little_endian(self):
+        data = b"II\x2a\x00" + b"\x00" * 20
+        assert _detect_binary_modality(data) == "image"
+
+    def test_tiff_big_endian(self):
+        data = b"MM\x00\x2a" + b"\x00" * 20
+        assert _detect_binary_modality(data) == "image"
+
+    # -- Audio formats --
+
+    def test_wav(self):
+        data = b"RIFF\x00\x00\x00\x00WAVE" + b"\x00" * 20
+        assert _detect_binary_modality(data) == "audio"
+
+    def test_flac(self):
+        data = b"fLaC" + b"\x00" * 20
+        assert _detect_binary_modality(data) == "audio"
+
+    def test_ogg(self):
+        data = b"OggS" + b"\x00" * 20
+        assert _detect_binary_modality(data) == "audio"
+
+    def test_mp3_id3(self):
+        data = b"ID3\x04\x00" + b"\x00" * 20
+        assert _detect_binary_modality(data) == "audio"
+
+    def test_mp3_sync_frame(self):
+        data = b"\xff\xfb\x90\x00" + b"\x00" * 20
+        assert _detect_binary_modality(data) == "audio"
+
+    def test_mp4_m4a(self):
+        data = b"\x00\x00\x00\x1cftyp" + b"M4A " + b"\x00" * 20
+        assert _detect_binary_modality(data) == "audio"
+
+    def test_au(self):
+        data = b".snd" + b"\x00" * 20
+        assert _detect_binary_modality(data) == "audio"
+
+    def test_aiff(self):
+        data = b"FORM\x00\x00\x00\x00AIFF" + b"\x00" * 20
+        assert _detect_binary_modality(data) == "audio"
+
+    # -- Fallback --
+
+    def test_unrecognized_defaults_to_image(self):
+        data = b"\x00\x01\x02\x03" + b"\x00" * 20
+        assert _detect_binary_modality(data) == "image"
+
+
+# ---------------------------------------------------------------------------
+# _infer_modality
+# ---------------------------------------------------------------------------
+
+
+class TestInferModality:
+    def test_text_strings(self):
+        series = _nw_series(["hello", "world"])
+        assert _infer_modality(series) == "text"
+
+    def test_text_default_for_all_null(self):
+        series = _nw_series([None, None, float("nan")])
+        assert _infer_modality(series) == "text"
+
+    def test_text_skips_leading_nulls(self):
+        series = _nw_series([None, float("nan"), "hello"])
+        assert _infer_modality(series) == "text"
+
+    def test_vector_ndarray(self):
+        series = _nw_series([np.array([1.0, 2.0, 3.0]), np.array([4.0, 5.0, 6.0])])
+        assert _infer_modality(series) == "vector"
+
+    def test_vector_list_of_floats(self):
+        series = _nw_series([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        assert _infer_modality(series) == "vector"
+
+    def test_vector_list_of_ints(self):
+        series = _nw_series([[1, 2, 3], [4, 5, 6]])
+        assert _infer_modality(series) == "vector"
+
+    def test_vector_empty_list_falls_through_to_text(self):
+        series = _nw_series([[], []])
+        assert _infer_modality(series) == "text"
+
+    def test_image_bytes(self):
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 20
+        series = _nw_series([png_bytes, png_bytes])
+        assert _infer_modality(series) == "image"
+
+    def test_audio_bytes(self):
+        wav_bytes = b"RIFF\x00\x00\x00\x00WAVE" + b"\x00" * 20
+        series = _nw_series([wav_bytes, wav_bytes])
+        assert _infer_modality(series) == "audio"
+
+    def test_image_dict_with_bytes(self):
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 20
+        series = _nw_series([{"bytes": png_bytes}])
+        assert _infer_modality(series) == "image"
+
+    def test_image_dict_with_bytes_as_list(self):
+        png_header = list(b"\x89PNG\r\n\x1a\n") + [0] * 20
+        series = _nw_series([{"bytes": png_header}])
+        assert _infer_modality(series) == "image"
+
+    def test_audio_dict_with_bytes_as_list(self):
+        wav_header = list(b"RIFF\x00\x00\x00\x00WAVE") + [0] * 20
+        series = _nw_series([{"bytes": wav_header}])
+        assert _infer_modality(series) == "audio"
+
+
+# ---------------------------------------------------------------------------
+# _to_canonical_text
+# ---------------------------------------------------------------------------
+
+
+class TestToCanonicalText:
+    def test_basic(self):
+        series = _nw_series(["hello", "world"])
+        result = _to_canonical_text(series)
+        assert result == ["hello", "world"]
+        assert type(result) is list
+        assert all(type(v) is str for v in result)
+
+    def test_null_replaced(self):
+        series = _nw_series(["hello", None, float("nan"), "world"])
+        result = _to_canonical_text(series)
+        assert result == ["hello", "null", "null", "world"]
+        assert all(type(v) is str for v in result)
+
+    def test_non_string_cast(self):
+        series = _nw_series([1, 2.5, True])
+        result = _to_canonical_text(series)
+        assert result == ["1", "2.5", "True"]
+        assert all(type(v) is str for v in result)
+
+
+# ---------------------------------------------------------------------------
+# _to_canonical_binary
+# ---------------------------------------------------------------------------
+
+
+class TestToCanonicalBinary:
+    def test_raw_bytes(self):
+        data = b"\x89PNG\r\n\x1a\n"
+        result = _to_canonical_binary(_nw_series([data]))
+        assert type(result) is list
+        assert len(result) == 1
+        assert result[0] == {"bytes": data}
+        assert type(result[0]) is dict
+        assert type(result[0]["bytes"]) is bytes
+
+    def test_dict_with_bytes(self):
+        data = b"\x89PNG\r\n\x1a\n"
+        result = _to_canonical_binary(_nw_series([{"bytes": data}]))
+        assert len(result) == 1
+        assert result[0] == {"bytes": data}
+        assert type(result[0]) is dict
+        assert type(result[0]["bytes"]) is bytes
+
+    def test_dict_with_bytes_as_list(self):
+        raw_list = [0x89, 0x50, 0x4E, 0x47]
+        result = _to_canonical_binary(_nw_series([{"bytes": raw_list}]))
+        assert len(result) == 1
+        assert result[0] == {"bytes": bytes(raw_list)}
+        assert type(result[0]) is dict
+        assert type(result[0]["bytes"]) is bytes
+
+    def test_invalid_type_raises(self):
+        with pytest.raises(ValueError, match="Cannot convert value of type"):
+            _to_canonical_binary(_nw_series([12345]))
+
+    def test_mixed_bytes_and_dicts(self):
+        raw = b"\xff\xd8"
+        items = [raw, {"bytes": raw}, {"bytes": [0xFF, 0xD8]}]
+        result = _to_canonical_binary(_nw_series(items))
+        assert type(result) is list
+        assert len(result) == 3
+        assert all(type(r) is dict and set(r.keys()) == {"bytes"} for r in result)
+        assert all(type(r["bytes"]) is bytes for r in result)
+        assert result[0]["bytes"] == raw
+        assert result[1]["bytes"] == raw
+        assert result[2]["bytes"] == bytes([0xFF, 0xD8])
+
+
+# ---------------------------------------------------------------------------
+# _to_canonical_vector
+# ---------------------------------------------------------------------------
+
+
+class TestToCanonicalVector:
+    def test_ndarray_input(self):
+        arr = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+        result = _to_canonical_vector(_nw_series([arr]))
+        assert type(result) is list
+        assert len(result) == 1
+        assert isinstance(result[0], np.ndarray)
+        assert result[0].dtype == np.float32
+        np.testing.assert_array_almost_equal(result[0], [1.0, 2.0, 3.0])
+
+    def test_list_input(self):
+        result = _to_canonical_vector(_nw_series([[1.0, 2.0, 3.0]]))
+        assert len(result) == 1
+        assert isinstance(result[0], np.ndarray)
+        assert result[0].dtype == np.float32
+        np.testing.assert_array_almost_equal(result[0], [1.0, 2.0, 3.0])
+
+    def test_mixed_ndarray_and_list(self):
+        items = [np.array([1.0, 2.0]), [3.0, 4.0]]
+        result = _to_canonical_vector(_nw_series(items))
+        assert type(result) is list
+        assert len(result) == 2
+        assert all(isinstance(r, np.ndarray) for r in result)
+        assert all(r.dtype == np.float32 for r in result)

--- a/packages/backend/tests/test_projection.py
+++ b/packages/backend/tests/test_projection.py
@@ -1,46 +1,399 @@
 # Copyright (c) 2025 Apple Inc. Licensed under MIT License.
 
+"""Tests for compute_projection using a placeholder embedder (no real models)."""
+
+import io
+import shutil
+
 import numpy as np
 import pandas as pd
-from embedding_atlas.projection import compute_vector_projection
+import polars as pl
+import pytest
+from embedding_atlas.embedding import create_embedder
+from embedding_atlas.projection import compute_projection
+from PIL import Image
+
+NUM_SAMPLES = 30
+EMBEDDING_DIM = 16
 
 
-def test_compute_vector_projection_basic():
-    """Test that compute_vector_projection adds projection columns to the dataframe."""
-    rng = np.random.default_rng(42)
-    vectors = rng.standard_normal((30, 16)).tolist()
+async def _fake_embedder(batch: list, *, model, embedder_args) -> np.ndarray:
+    """Return deterministic random vectors seeded by batch length."""
+    rng = np.random.RandomState(len(batch))
+    return rng.randn(len(batch), EMBEDDING_DIM).astype(np.float32)
+
+
+def _make_random_image_bytes(width=64, height=64, seed=0) -> bytes:
+    rng = np.random.RandomState(seed)
+    pixels = rng.randint(0, 255, (height, width, 3), dtype=np.uint8)
+    img = Image.fromarray(pixels, "RGB")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture()
+def cache_root(tmp_path):
+    path = tmp_path / "cache"
+    path.mkdir()
+    yield path
+    shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.fixture()
+def text_df():
+    return pd.DataFrame({"text": [f"sentence {i}" for i in range(NUM_SAMPLES)]})
+
+
+@pytest.fixture()
+def image_df():
+    images = [{"bytes": _make_random_image_bytes(seed=i)} for i in range(NUM_SAMPLES)]
+    return pd.DataFrame({"image": images})
+
+
+@pytest.fixture()
+def vector_df():
+    rng = np.random.RandomState(42)
+    vectors = [rng.randn(EMBEDDING_DIM).astype(np.float32) for _ in range(NUM_SAMPLES)]
+    return pd.DataFrame({"vec": vectors})
+
+
+# ---------------------------------------------------------------------------
+# Text modality
+# ---------------------------------------------------------------------------
+
+
+def test_text(text_df, cache_root):
+    result = compute_projection(
+        text_df,
+        inputs="text",
+        modality="text",
+        embedder=_fake_embedder,
+        cache_root=cache_root,
+    )
+    assert "projection_x" in result.columns
+    assert "projection_y" in result.columns
+    assert "neighbors" in result.columns
+    assert len(result) == NUM_SAMPLES
+
+
+def test_text_auto_modality(text_df, cache_root):
+    result = compute_projection(
+        text_df,
+        inputs="text",
+        modality="auto",
+        embedder=_fake_embedder,
+        cache_root=cache_root,
+    )
+    assert len(result) == NUM_SAMPLES
+    assert result["projection_x"].notna().all()
+
+
+# ---------------------------------------------------------------------------
+# Image modality
+# ---------------------------------------------------------------------------
+
+
+def test_image(image_df, cache_root):
+    result = compute_projection(
+        image_df,
+        inputs="image",
+        modality="image",
+        embedder=_fake_embedder,
+        cache_root=cache_root,
+    )
+    assert len(result) == NUM_SAMPLES
+    assert "projection_x" in result.columns
+
+
+def test_image_auto_modality(image_df, cache_root):
+    result = compute_projection(
+        image_df,
+        inputs="image",
+        modality="auto",
+        embedder=_fake_embedder,
+        cache_root=cache_root,
+    )
+    assert len(result) == NUM_SAMPLES
+
+
+# ---------------------------------------------------------------------------
+# Vector modality (no embedder needed)
+# ---------------------------------------------------------------------------
+
+
+def test_vector(vector_df, cache_root):
+    result = compute_projection(
+        vector_df,
+        inputs="vec",
+        modality="vector",
+        cache_root=cache_root,
+    )
+    assert len(result) == NUM_SAMPLES
+    assert "projection_x" in result.columns
+
+
+def test_vector_auto_modality(vector_df, cache_root):
+    result = compute_projection(
+        vector_df,
+        inputs="vec",
+        modality="auto",
+        cache_root=cache_root,
+    )
+    assert len(result) == NUM_SAMPLES
+
+
+# ---------------------------------------------------------------------------
+# Custom embedder receives correct data
+# ---------------------------------------------------------------------------
+
+
+def test_custom_embedder_receives_text_strings(text_df, cache_root):
+    """Verify the custom embedder receives canonical text (list[str])."""
+    received = []
+
+    async def capture_embedder(batch, *, model, embedder_args):
+        received.extend(batch)
+        rng = np.random.RandomState(0)
+        return rng.randn(len(batch), EMBEDDING_DIM).astype(np.float32)
+
+    compute_projection(
+        text_df,
+        inputs="text",
+        modality="text",
+        embedder=capture_embedder,
+        cache_root=cache_root,
+    )
+    assert len(received) == NUM_SAMPLES
+    assert all(isinstance(item, str) for item in received)
+
+
+def test_custom_embedder_receives_image_dicts(image_df, cache_root):
+    """Verify the custom embedder receives canonical image dicts."""
+    received = []
+
+    async def capture_embedder(batch, *, model, embedder_args):
+        received.extend(batch)
+        rng = np.random.RandomState(0)
+        return rng.randn(len(batch), EMBEDDING_DIM).astype(np.float32)
+
+    compute_projection(
+        image_df,
+        inputs="image",
+        modality="image",
+        embedder=capture_embedder,
+        cache_root=cache_root,
+    )
+    assert len(received) == NUM_SAMPLES
+    assert all(isinstance(item, dict) and "bytes" in item for item in received)
+
+
+def test_custom_embedder_receives_model_and_args(text_df, cache_root):
+    """Verify model and embedder_args are forwarded to the custom embedder."""
+    captured_kwargs = {}
+
+    async def capture_embedder(batch, *, model, embedder_args):
+        captured_kwargs["model"] = model
+        captured_kwargs["embedder_args"] = embedder_args
+        rng = np.random.RandomState(0)
+        return rng.randn(len(batch), EMBEDDING_DIM).astype(np.float32)
+
+    compute_projection(
+        text_df,
+        inputs="text",
+        modality="text",
+        embedder=capture_embedder,
+        model="my-model",
+        embedder_args={"api_key": "test-key"},
+        cache_root=cache_root,
+    )
+    assert captured_kwargs["model"] == "my-model"
+    assert captured_kwargs["embedder_args"] == {"api_key": "test-key"}
+
+
+# ---------------------------------------------------------------------------
+# API behavior
+# ---------------------------------------------------------------------------
+
+
+def test_custom_column_names(text_df, cache_root):
+    result = compute_projection(
+        text_df,
+        inputs="text",
+        modality="text",
+        x="cx",
+        y="cy",
+        neighbors="nn",
+        embedder=_fake_embedder,
+        cache_root=cache_root,
+    )
+    assert "cx" in result.columns
+    assert "cy" in result.columns
+    assert "nn" in result.columns
+
+
+def test_no_neighbors(text_df, cache_root):
+    result = compute_projection(
+        text_df,
+        inputs="text",
+        modality="text",
+        neighbors=None,
+        embedder=_fake_embedder,
+        cache_root=cache_root,
+    )
+    assert "projection_x" in result.columns
+    assert "projection_y" in result.columns
+    assert "neighbors" not in result.columns
+
+
+def test_returns_new_dataframe(text_df, cache_root):
+    original_columns = list(text_df.columns)
+    result = compute_projection(
+        text_df,
+        inputs="text",
+        modality="text",
+        embedder=_fake_embedder,
+        cache_root=cache_root,
+    )
+    assert list(text_df.columns) == original_columns
+    assert "projection_x" not in text_df.columns
+    assert result is not text_df
+
+
+def test_preserves_original_data(text_df, cache_root):
+    text_df["id"] = range(len(text_df))
+    result = compute_projection(
+        text_df,
+        inputs="text",
+        modality="text",
+        embedder=_fake_embedder,
+        cache_root=cache_root,
+    )
+    assert "id" in result.columns
+    assert "text" in result.columns
+    assert list(result["id"]) == list(range(NUM_SAMPLES))
+
+
+def test_neighbors_structure(text_df, cache_root):
+    result = compute_projection(
+        text_df,
+        inputs="text",
+        modality="text",
+        embedder=_fake_embedder,
+        cache_root=cache_root,
+    )
+    for neighbor in result["neighbors"]:
+        assert isinstance(neighbor, dict)
+        assert "ids" in neighbor
+        assert "distances" in neighbor
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_modality(text_df, cache_root):
+    with pytest.raises(ValueError, match="Unknown modality"):
+        compute_projection(
+            text_df,
+            inputs="text",
+            modality="unknown",
+            embedder=_fake_embedder,
+            cache_root=cache_root,
+        )
+
+
+def test_invalid_column(text_df, cache_root):
+    with pytest.raises(KeyError):
+        compute_projection(
+            text_df,
+            inputs="nonexistent",
+            modality="text",
+            embedder=_fake_embedder,
+            cache_root=cache_root,
+        )
+
+
+def test_unknown_embedder_name(text_df, cache_root):
+    with pytest.raises(ValueError, match="Unknown embedder"):
+        compute_projection(
+            text_df,
+            inputs="text",
+            modality="text",
+            embedder="nonexistent-engine",
+            cache_root=cache_root,
+        )
+
+
+def test_sentence_transformers_rejects_image():
+    with pytest.raises(NotImplementedError, match="only supports text"):
+        create_embedder(
+            "sentence-transformers", modality="image", model=None, embedder_args={}
+        )
+
+
+def test_underscore_embedder_name(text_df, cache_root):
+    """Test that 'sentence_transformers' (underscore) is accepted and normalized.
+
+    We can't do a full integration test without a real model, so we verify
+    indirectly: pass a vector modality (which skips the embedder entirely)
+    with the underscore variant to confirm it doesn't blow up on resolution.
+    """
+    rng = np.random.RandomState(42)
+    vectors = [rng.randn(EMBEDDING_DIM).astype(np.float32) for _ in range(NUM_SAMPLES)]
     df = pd.DataFrame({"vec": vectors})
-
-    compute_vector_projection(df, vector="vec")
-
-    assert "projection_x" in df.columns
-    assert "projection_y" in df.columns
-    assert "neighbors" in df.columns
-    assert len(df) == 30
-    assert df["projection_x"].notna().all()
-    assert df["projection_y"].notna().all()
-
-
-def test_compute_vector_projection_custom_columns():
-    """Test custom column names for x, y, and neighbors."""
-    rng = np.random.default_rng(42)
-    vectors = [rng.standard_normal(8) for _ in range(30)]
-    df = pd.DataFrame({"vec": vectors})
-
-    compute_vector_projection(df, vector="vec", x="cx", y="cy", neighbors="nn")
-
-    assert "cx" in df.columns
-    assert "cy" in df.columns
-    assert "nn" in df.columns
+    result = compute_projection(
+        df,
+        inputs="vec",
+        modality="vector",
+        embedder="sentence_transformers",
+        cache_root=cache_root,
+    )
+    assert len(result) == NUM_SAMPLES
 
 
-def test_compute_vector_projection_no_neighbors():
-    """Test that neighbors column is not added when neighbors=None."""
-    rng = np.random.default_rng(42)
-    df = pd.DataFrame({"vec": rng.standard_normal((30, 8)).tolist()})
+# ---------------------------------------------------------------------------
+# Polars backend
+# ---------------------------------------------------------------------------
 
-    compute_vector_projection(df, vector="vec", neighbors=None)
 
-    assert "projection_x" in df.columns
-    assert "projection_y" in df.columns
-    assert "neighbors" not in df.columns
+@pytest.fixture()
+def text_pl():
+    return pl.DataFrame({"text": [f"sentence {i}" for i in range(NUM_SAMPLES)]})
+
+
+@pytest.fixture()
+def vector_pl():
+    rng = np.random.RandomState(42)
+    vectors = [
+        rng.randn(EMBEDDING_DIM).astype(np.float32).tolist() for _ in range(NUM_SAMPLES)
+    ]
+    return pl.DataFrame({"vec": vectors})
+
+
+def test_text_polars(text_pl, cache_root):
+    result = compute_projection(
+        text_pl,
+        inputs="text",
+        modality="text",
+        embedder=_fake_embedder,
+        cache_root=cache_root,
+    )
+    assert isinstance(result, pl.DataFrame)
+    assert "projection_x" in result.columns
+    assert "projection_y" in result.columns
+    assert "neighbors" in result.columns
+    assert len(result) == NUM_SAMPLES
+
+
+def test_vector_polars(vector_pl, cache_root):
+    result = compute_projection(
+        vector_pl,
+        inputs="vec",
+        modality="vector",
+        cache_root=cache_root,
+    )
+    assert isinstance(result, pl.DataFrame)
+    assert "projection_x" in result.columns
+    assert len(result) == NUM_SAMPLES

--- a/packages/backend/tests/test_projection_litellm.py
+++ b/packages/backend/tests/test_projection_litellm.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+"""Integration tests for the litellm embedder through compute_projection."""
+
+import io
+import os
+import shutil
+
+import numpy as np
+import pandas as pd
+import pytest
+from embedding_atlas.projection import compute_projection
+from PIL import Image
+
+# Skip unless --run-external is passed AND GEMINI_API_KEY is set.
+pytestmark = [
+    pytest.mark.external,
+    pytest.mark.skipif(
+        not os.environ.get("GEMINI_API_KEY"), reason="GEMINI_API_KEY not set"
+    ),
+]
+
+NUM_SAMPLES = 30
+MODEL = "gemini/gemini-embedding-2-preview"
+
+
+def _make_random_image_bytes(width=64, height=64, seed=0) -> bytes:
+    rng = np.random.RandomState(seed)
+    pixels = rng.randint(0, 255, (height, width, 3), dtype=np.uint8)
+    img = Image.fromarray(pixels, "RGB")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture()
+def cache_root(tmp_path):
+    path = tmp_path / "cache"
+    path.mkdir()
+    yield path
+    shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.fixture()
+def text_df():
+    return pd.DataFrame(
+        {
+            "text": [
+                "the cat sat on the mat",
+                "the dog chased the ball",
+                "a bird flew over the house",
+                "fish swim in the ocean",
+                "the sun sets behind the mountain",
+                "rain falls on the city streets",
+                "a child reads a colorful book",
+                "music plays softly in the room",
+                "the train arrived at the station",
+                "flowers bloom in the garden",
+                "stars shine brightly at night",
+                "the river flows through the valley",
+                "a painter works on a canvas",
+                "the wind blows through the trees",
+                "a chef prepares a delicious meal",
+                "snow covers the mountain peaks",
+                "the boat sails across the lake",
+                "birds sing in the early morning",
+                "a student studies for an exam",
+                "the moon rises over the horizon",
+                "waves crash on the sandy beach",
+                "a farmer tends to the crops",
+                "the clock ticks on the wall",
+                "leaves fall from the old oak tree",
+                "a dancer moves across the stage",
+                "thunder rumbles in the distance",
+                "the library is quiet and peaceful",
+                "a runner sprints to the finish line",
+                "the cat purrs softly on the couch",
+                "a scientist looks through a microscope",
+            ]
+        }
+    )
+
+
+@pytest.fixture()
+def image_df():
+    images = [{"bytes": _make_random_image_bytes(seed=i)} for i in range(NUM_SAMPLES)]
+    return pd.DataFrame({"image": images})
+
+
+def _assert_projection_result(result, n=NUM_SAMPLES):
+    assert "projection_x" in result.columns
+    assert "projection_y" in result.columns
+    assert "neighbors" in result.columns
+    assert len(result) == n
+    assert result["projection_x"].notna().all()
+    assert result["projection_y"].notna().all()
+    for neighbor in result["neighbors"]:
+        assert isinstance(neighbor, dict)
+        assert "ids" in neighbor
+        assert "distances" in neighbor
+
+
+# ---------------------------------------------------------------------------
+# Text modality
+# ---------------------------------------------------------------------------
+
+
+def test_text(text_df, cache_root):
+    result = compute_projection(
+        text_df,
+        inputs="text",
+        modality="text",
+        embedder="litellm",
+        model=MODEL,
+        cache_root=cache_root,
+    )
+    _assert_projection_result(result)
+
+
+def test_text_auto_modality(text_df, cache_root):
+    result = compute_projection(
+        text_df,
+        inputs="text",
+        modality="auto",
+        embedder="litellm",
+        model=MODEL,
+        cache_root=cache_root,
+    )
+    _assert_projection_result(result)
+
+
+# ---------------------------------------------------------------------------
+# Image modality
+# ---------------------------------------------------------------------------
+
+
+def test_image(image_df, cache_root):
+    result = compute_projection(
+        image_df,
+        inputs="image",
+        modality="image",
+        embedder="litellm",
+        model=MODEL,
+        cache_root=cache_root,
+    )
+    _assert_projection_result(result)
+
+
+def test_image_auto_modality(image_df, cache_root):
+    result = compute_projection(
+        image_df,
+        inputs="image",
+        modality="auto",
+        embedder="litellm",
+        model=MODEL,
+        cache_root=cache_root,
+    )
+    _assert_projection_result(result)

--- a/packages/backend/tests/test_projection_transformers.py
+++ b/packages/backend/tests/test_projection_transformers.py
@@ -1,0 +1,339 @@
+# Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+import io
+import shutil
+
+import numpy as np
+import pandas as pd
+import pytest
+from embedding_atlas.projection import compute_projection
+from PIL import Image
+
+# Skip all tests in this module unless --run-external is passed to pytest.
+pytestmark = pytest.mark.external
+
+NUM_SAMPLES = 30
+EMBEDDERS = ["sentence-transformers", "transformers"]
+
+
+def _make_random_image_bytes(width=64, height=64, seed=0) -> bytes:
+    """Generate a random RGB image as PNG bytes."""
+    rng = np.random.RandomState(seed)
+    pixels = rng.randint(0, 255, (height, width, 3), dtype=np.uint8)
+    img = Image.fromarray(pixels, "RGB")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_random_wav_bytes(duration=1.0, sample_rate=48000, seed=0) -> bytes:
+    """Generate a random mono WAV file as bytes."""
+    import soundfile as sf
+
+    rng = np.random.RandomState(seed)
+    samples = rng.randn(int(sample_rate * duration)).astype(np.float32)
+    buf = io.BytesIO()
+    sf.write(buf, samples, sample_rate, format="WAV")
+    return buf.getvalue()
+
+
+@pytest.fixture()
+def cache_root(tmp_path):
+    path = tmp_path / "cache"
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir()
+    yield path
+    shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.fixture()
+def text_df():
+    """A simple DataFrame with text data."""
+    return pd.DataFrame(
+        {
+            "text": [
+                "the cat sat on the mat",
+                "the dog chased the ball",
+                "a bird flew over the house",
+                "fish swim in the ocean",
+                "the sun sets behind the mountain",
+                "rain falls on the city streets",
+                "a child reads a colorful book",
+                "music plays softly in the room",
+                "the train arrived at the station",
+                "flowers bloom in the garden",
+                "stars shine brightly at night",
+                "the river flows through the valley",
+                "a painter works on a canvas",
+                "the wind blows through the trees",
+                "a chef prepares a delicious meal",
+                "snow covers the mountain peaks",
+                "the boat sails across the lake",
+                "birds sing in the early morning",
+                "a student studies for an exam",
+                "the moon rises over the horizon",
+                "waves crash on the sandy beach",
+                "a farmer tends to the crops",
+                "the clock ticks on the wall",
+                "leaves fall from the old oak tree",
+                "a dancer moves across the stage",
+                "thunder rumbles in the distance",
+                "the library is quiet and peaceful",
+                "a runner sprints to the finish line",
+                "the cat purrs softly on the couch",
+                "a scientist looks through a microscope",
+            ]
+        }
+    )
+
+
+@pytest.fixture()
+def image_df():
+    images = [{"bytes": _make_random_image_bytes(seed=i)} for i in range(NUM_SAMPLES)]
+    return pd.DataFrame({"image": images})
+
+
+@pytest.fixture()
+def audio_df():
+    audios = [{"bytes": _make_random_wav_bytes(seed=i)} for i in range(NUM_SAMPLES)]
+    return pd.DataFrame({"audio": audios})
+
+
+@pytest.fixture()
+def vector_df():
+    rng = np.random.RandomState(42)
+    vectors = [rng.randn(32).astype(np.float32) for _ in range(NUM_SAMPLES)]
+    return pd.DataFrame({"vec": vectors})
+
+
+def _assert_projection_result(result, n=NUM_SAMPLES):
+    assert "projection_x" in result.columns
+    assert "projection_y" in result.columns
+    assert "neighbors" in result.columns
+    assert len(result) == n
+    assert result["projection_x"].notna().all()
+    assert result["projection_y"].notna().all()
+    for neighbor in result["neighbors"]:
+        assert isinstance(neighbor, dict)
+        assert "ids" in neighbor
+        assert "distances" in neighbor
+
+
+# ---------------------------------------------------------------------------
+# Text modality
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("embedder", EMBEDDERS)
+def test_text(text_df, cache_root, embedder):
+    """Test text embedding with each embedder."""
+    result = compute_projection(
+        text_df,
+        inputs="text",
+        modality="text",
+        embedder=embedder,
+        cache_root=cache_root,
+    )
+    _assert_projection_result(result)
+
+
+@pytest.mark.parametrize("embedder", EMBEDDERS)
+def test_text_auto_modality(text_df, cache_root, embedder):
+    """Test that auto modality correctly detects text."""
+    result = compute_projection(
+        text_df,
+        inputs="text",
+        modality="auto",
+        embedder=embedder,
+        cache_root=cache_root,
+    )
+    _assert_projection_result(result)
+
+
+# ---------------------------------------------------------------------------
+# Image modality
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("embedder", ["transformers"])
+def test_image(image_df, cache_root, embedder):
+    """Test image embedding with each embedder."""
+    result = compute_projection(
+        image_df,
+        inputs="image",
+        modality="image",
+        embedder=embedder,
+        cache_root=cache_root,
+    )
+    _assert_projection_result(result)
+
+
+def test_image_auto_modality(image_df, cache_root):
+    """Test that auto modality correctly detects image."""
+    result = compute_projection(
+        image_df,
+        inputs="image",
+        modality="auto",
+        cache_root=cache_root,
+    )
+    _assert_projection_result(result)
+
+
+# ---------------------------------------------------------------------------
+# Audio modality
+# ---------------------------------------------------------------------------
+
+
+def test_audio(audio_df, cache_root):
+    """Test audio embedding with CLAP via transformers."""
+    result = compute_projection(
+        audio_df,
+        inputs="audio",
+        modality="audio",
+        embedder="transformers",
+        cache_root=cache_root,
+    )
+    _assert_projection_result(result)
+
+
+def test_audio_auto_modality(audio_df, cache_root):
+    """Test that auto modality correctly detects audio."""
+    result = compute_projection(
+        audio_df,
+        inputs="audio",
+        modality="auto",
+        cache_root=cache_root,
+    )
+    _assert_projection_result(result)
+
+
+# ---------------------------------------------------------------------------
+# Vector modality (no embedder needed)
+# ---------------------------------------------------------------------------
+
+
+def test_vector(vector_df, cache_root):
+    result = compute_projection(
+        vector_df,
+        inputs="vec",
+        modality="vector",
+        cache_root=cache_root,
+    )
+    _assert_projection_result(result)
+
+
+def test_vector_auto_modality(vector_df, cache_root):
+    result = compute_projection(
+        vector_df,
+        inputs="vec",
+        modality="auto",
+        cache_root=cache_root,
+    )
+    _assert_projection_result(result)
+
+
+# ---------------------------------------------------------------------------
+# API behavior tests
+# ---------------------------------------------------------------------------
+
+
+def test_custom_column_names(text_df, cache_root):
+    """Test custom column names for x, y, and neighbors."""
+    result = compute_projection(
+        text_df,
+        inputs="text",
+        modality="text",
+        x="cx",
+        y="cy",
+        neighbors="nn",
+        embedder="sentence-transformers",
+        cache_root=cache_root,
+    )
+    assert "cx" in result.columns
+    assert "cy" in result.columns
+    assert "nn" in result.columns
+
+
+def test_no_neighbors(text_df, cache_root):
+    """Test that neighbors column is not added when neighbors=None."""
+    result = compute_projection(
+        text_df,
+        inputs="text",
+        modality="text",
+        neighbors=None,
+        embedder="sentence-transformers",
+        cache_root=cache_root,
+    )
+    assert "projection_x" in result.columns
+    assert "projection_y" in result.columns
+    assert "neighbors" not in result.columns
+
+
+def test_returns_new_dataframe(text_df, cache_root):
+    """Test that compute_projection returns a new DataFrame, preserving the original."""
+    original_columns = list(text_df.columns)
+    result = compute_projection(
+        text_df,
+        inputs="text",
+        modality="text",
+        embedder="sentence-transformers",
+        cache_root=cache_root,
+    )
+    assert list(text_df.columns) == original_columns
+    assert "projection_x" not in text_df.columns
+    assert result is not text_df
+
+
+def test_preserves_original_data(text_df, cache_root):
+    """Test that original DataFrame columns are preserved in the result."""
+    text_df["id"] = range(len(text_df))
+    result = compute_projection(
+        text_df,
+        inputs="text",
+        modality="text",
+        embedder="sentence-transformers",
+        cache_root=cache_root,
+    )
+    assert "id" in result.columns
+    assert "text" in result.columns
+    assert list(result["id"]) == list(range(30))
+
+
+def test_neighbors_structure(text_df, cache_root):
+    """Test that the neighbors column contains dicts with 'ids' and 'distances' keys."""
+    result = compute_projection(
+        text_df,
+        inputs="text",
+        modality="text",
+        embedder="sentence-transformers",
+        cache_root=cache_root,
+    )
+    for neighbor in result["neighbors"]:
+        assert isinstance(neighbor, dict)
+        assert "ids" in neighbor
+        assert "distances" in neighbor
+
+
+def test_invalid_modality(text_df, cache_root):
+    """Test that an invalid modality raises ValueError."""
+    with pytest.raises(ValueError, match="Unknown modality"):
+        compute_projection(
+            text_df,
+            inputs="text",
+            modality="unknown",
+            embedder="sentence-transformers",
+            cache_root=cache_root,
+        )
+
+
+def test_invalid_column(text_df, cache_root):
+    """Test that a missing column raises KeyError."""
+    with pytest.raises(KeyError):
+        compute_projection(
+            text_df,
+            inputs="nonexistent",
+            modality="text",
+            embedder="sentence-transformers",
+            cache_root=cache_root,
+        )

--- a/packages/backend/uv.lock
+++ b/packages/backend/uv.lock
@@ -915,6 +915,7 @@ dependencies = [
     { name = "inquirer" },
     { name = "litellm" },
     { name = "llvmlite" },
+    { name = "narwhals" },
     { name = "pandas" },
     { name = "platformdirs" },
     { name = "pyarrow" },
@@ -932,7 +933,11 @@ dev = [
     { name = "datasets" },
     { name = "docutils" },
     { name = "jupyterlab" },
+    { name = "polars" },
+    { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "soundfile" },
     { name = "streamlit" },
 ]
 
@@ -947,6 +952,7 @@ requires-dist = [
     { name = "inquirer", specifier = ">=3.0.0" },
     { name = "litellm", specifier = ">=1.70.0,!=1.82.7,!=1.82.8" },
     { name = "llvmlite", specifier = ">=0.43.0" },
+    { name = "narwhals", specifier = ">=2.0.0" },
     { name = "pandas", specifier = ">=2.2.0" },
     { name = "platformdirs", specifier = ">=4.3.0" },
     { name = "pyarrow", specifier = ">=18.0.0" },
@@ -964,7 +970,11 @@ dev = [
     { name = "datasets", specifier = ">=3.1.0" },
     { name = "docutils", specifier = ">=0.22.0" },
     { name = "jupyterlab", specifier = ">=4.3.0" },
+    { name = "polars", specifier = ">=1.0.0" },
+    { name = "pyright", specifier = ">=1.1.0" },
     { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "soundfile", specifier = ">=0.12.0" },
     { name = "streamlit", specifier = ">=1.43.0" },
 ]
 
@@ -2277,6 +2287,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "notebook-shim"
 version = "0.2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2756,6 +2775,34 @@ wheels = [
 ]
 
 [[package]]
+name = "polars"
+version = "1.39.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/ab/f19e592fce9e000da49c96bf35e77cef67f9cb4b040bfa538a2764c0263e/polars-1.39.3.tar.gz", hash = "sha256:2e016c7f3e8d14fa777ef86fe0477cec6c67023a20ba4c94d6e8431eefe4a63c", size = 728987, upload-time = "2026-03-20T11:16:24.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/db/08f4ca10c5018813e7e0b59e4472302328b3d2ab1512f5a2157a814540e0/polars-1.39.3-py3-none-any.whl", hash = "sha256:c2b955ccc0a08a2bc9259785decf3d5c007b489b523bf2390cf21cec2bb82a56", size = 823985, upload-time = "2026-03-20T11:14:23.619Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.39.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/39/c8688696bc22b6c501e3b82ef3be10e543c07a785af5660f30997cd22dd2/polars_runtime_32-1.39.3.tar.gz", hash = "sha256:c728e4f469cafab501947585f36311b8fb222d3e934c6209e83791e0df20b29d", size = 2872335, upload-time = "2026-03-20T11:16:26.581Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/74/1b41205f7368c9375ab1dea91178eaa20435fe3eff036390a53a7660b416/polars_runtime_32-1.39.3-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:425c0b220b573fa097b4042edff73114cc6d23432a21dfd2dc41adf329d7d2e9", size = 45273243, upload-time = "2026-03-20T11:14:26.691Z" },
+    { url = "https://files.pythonhosted.org/packages/90/bf/297716b3095fe719be20fcf7af1d2b6ab069c38199bbace2469608a69b3a/polars_runtime_32-1.39.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:ef5884711e3c617d7dc93519a7d038e242f5741cfe5fe9afd32d58845d86c562", size = 40842924, upload-time = "2026-03-20T11:14:31.154Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/e65236d9d0d9babfa0ecba593413c06530fca60a8feb8f66243aa5dba92e/polars_runtime_32-1.39.3-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06b47f535eb1f97a9a1e5b0053ef50db3a4276e241178e37bbb1a38b1fa53b14", size = 43220650, upload-time = "2026-03-20T11:14:35.458Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/15/fc3e43f3fdf3f20b7dfb5abe871ab6162cf8fb4aeabf4cfad822d5dc4c79/polars_runtime_32-1.39.3-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8bc9e13dc1d2e828331f2fe8ccbc9757554dc4933a8d3e85e906b988178f95ed", size = 46877498, upload-time = "2026-03-20T11:14:40.14Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/81/bd5f895919e32c6ab0a7786cd0c0ca961cb03152c47c3645808b54383f31/polars_runtime_32-1.39.3-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:363d49e3a3e638fc943e2b9887940300a7d06789930855a178a4727949259dc2", size = 43380176, upload-time = "2026-03-20T11:14:45.566Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/3e/c86433c3b5ec0315bdfc7640d0c15d41f1216c0103a0eab9a9b5147d6c4c/polars_runtime_32-1.39.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7c206bdcc7bc62ea038d6adea8e44b02f0e675e0191a54c810703b4895208ea4", size = 46485933, upload-time = "2026-03-20T11:14:51.155Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ce/200b310cf91f98e652eb6ea09fdb3a9718aa0293ebf113dce325797c8572/polars_runtime_32-1.39.3-cp310-abi3-win_amd64.whl", hash = "sha256:d66ca522517554a883446957539c40dc7b75eb0c2220357fb28bc8940d305339", size = 46995458, upload-time = "2026-03-20T11:14:56.074Z" },
+    { url = "https://files.pythonhosted.org/packages/da/76/2d48927e0aa2abbdde08cbf4a2536883b73277d47fbeca95e952de86df34/polars_runtime_32-1.39.3-cp310-abi3-win_arm64.whl", hash = "sha256:f49f51461de63f13e5dd4eb080421c8f23f856945f3f8bd5b2b1f59da52c2860", size = 41857648, upload-time = "2026-03-20T11:15:01.142Z" },
+]
+
+[[package]]
 name = "prometheus-client"
 version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3175,6 +3222,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3188,6 +3248,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]
@@ -3884,6 +3957,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soundfile"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/41/9b873a8c055582859b239be17902a85339bec6a30ad162f98c9b0288a2cc/soundfile-0.13.1.tar.gz", hash = "sha256:b2c68dab1e30297317080a5b43df57e302584c49e2942defdde0acccc53f0e5b", size = 46156, upload-time = "2025-01-25T09:17:04.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/28/e2a36573ccbcf3d57c00626a21fe51989380636e821b341d36ccca0c1c3a/soundfile-0.13.1-py2.py3-none-any.whl", hash = "sha256:a23c717560da2cf4c7b5ae1142514e0fd82d6bbd9dfc93a50423447142f2c445", size = 25751, upload-time = "2025-01-25T09:16:44.235Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ab/73e97a5b3cc46bba7ff8650a1504348fa1863a6f9d57d7001c6b67c5f20e/soundfile-0.13.1-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:82dc664d19831933fe59adad199bf3945ad06d84bc111a5b4c0d3089a5b9ec33", size = 1142250, upload-time = "2025-01-25T09:16:47.583Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e5/58fd1a8d7b26fc113af244f966ee3aecf03cb9293cb935daaddc1e455e18/soundfile-0.13.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:743f12c12c4054921e15736c6be09ac26b3b3d603aef6fd69f9dde68748f2593", size = 1101406, upload-time = "2025-01-25T09:16:49.662Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ae/c0e4a53d77cf6e9a04179535766b3321b0b9ced5f70522e4caf9329f0046/soundfile-0.13.1-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:9c9e855f5a4d06ce4213f31918653ab7de0c5a8d8107cd2427e44b42df547deb", size = 1235729, upload-time = "2025-01-25T09:16:53.018Z" },
+    { url = "https://files.pythonhosted.org/packages/57/5e/70bdd9579b35003a489fc850b5047beeda26328053ebadc1fb60f320f7db/soundfile-0.13.1-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:03267c4e493315294834a0870f31dbb3b28a95561b80b134f0bd3cf2d5f0e618", size = 1313646, upload-time = "2025-01-25T09:16:54.872Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/df/8c11dc4dfceda14e3003bb81a0d0edcaaf0796dd7b4f826ea3e532146bba/soundfile-0.13.1-py2.py3-none-win32.whl", hash = "sha256:c734564fab7c5ddf8e9be5bf70bab68042cd17e9c214c06e365e20d64f9a69d5", size = 899881, upload-time = "2025-01-25T09:16:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/6b761de83277f2f02ded7e7ea6f07828ec78e4b229b80e4ca55dd205b9dc/soundfile-0.13.1-py2.py3-none-win_amd64.whl", hash = "sha256:1e70a05a0626524a69e9f0f4dd2ec174b4e9567f4d8b6c11d38b5c289be36ee9", size = 1019162, upload-time = "2025-01-25T09:16:59.573Z" },
 ]
 
 [[package]]

--- a/packages/docs/algorithms.md
+++ b/packages/docs/algorithms.md
@@ -6,9 +6,7 @@ The `embedding-atlas` package contains some useful algorithms for computing embe
 
 This package provides a WebAssembly implementation of [UMAP (Uniform Manifold Approximation and Projection for Dimension Reduction)](https://umap-learn.readthedocs.io/en/latest/) and approximate nearest neighbor search.
 
-The UMAP implementation is [umappp](https://github.com/libscran/umappp/) by Aaron Lun.
-
-The approximate nearest neighbor search is based on [knncolle](https://github.com/knncolle/knncolle), with two algorithms, including HNSW ([hnswlib](https://github.com/nmslib/hnswlib)) and [nndescent](https://github.com/brj0/nndescent) by Jon Brugger.
+The implementation is based on the original Python libraries [umap-learn](https://github.com/lmcinnes/umap) and [pynndescent](https://github.com/lmcinnes/pynndescent) by Leland McInnes, ported to Rust and compiled to WebAssembly.
 
 To initialize the UMAP algorithm, use `createUMAP`:
 

--- a/packages/docs/generate_cache.py
+++ b/packages/docs/generate_cache.py
@@ -9,7 +9,7 @@ import click
 import duckdb
 import pandas as pd
 import requests
-from embedding_atlas.projection import compute_text_projection
+from embedding_atlas.projection import compute_projection
 
 
 def load_and_check_integrity(url: str, *, sha256: str) -> bytes:
@@ -46,9 +46,10 @@ def generate_dataset_embedding(
 
     umap_args = {"random_state": 42} | umap_args
 
-    compute_text_projection(
+    df = compute_projection(
         df,
-        text="text",
+        inputs="text",
+        modality="text",
         x="x",
         y="y",
         neighbors="neighbors",

--- a/packages/docs/streamlit.md
+++ b/packages/docs/streamlit.md
@@ -12,10 +12,11 @@ pip install embedding-atlas
 
 ```python
 from embedding_atlas.streamlit import embedding_atlas
-from embedding_atlas.projection import compute_text_projection
+from embedding_atlas.projection import compute_projection
 
 # Compute text embedding and projection of the embedding
-compute_text_projection(df, text="description",
+# Note: In async environments (e.g. Jupyter notebooks), use async_compute_projection instead.
+df = compute_projection(df, inputs="description", modality="text",
     x="projection_x", y="projection_y", neighbors="neighbors"
 )
 

--- a/packages/docs/tool.md
+++ b/packages/docs/tool.md
@@ -49,7 +49,7 @@ embedding-atlas huggingface_org/dataset_name
 
 ## Visualizing Embeddings
 
-The script will use [SentenceTransformers](https://sbert.net/) to compute embedding vectors for the specified column containing the text or image data. You may use the `--model` option to specify an embedding model. If not specified, a default model will be used. The current defaults are `all-MiniLM-L6-v2` for text and `google/vit-base-patch16-384` for images, but these are subject to change in future releases.
+The script will compute embedding vectors for the specified column containing the text, image, or audio data. By default, it uses [SentenceTransformers](https://sbert.net/) for text and [HuggingFace Transformers](https://huggingface.co/docs/transformers/) for images and audio. You can also use [LiteLLM](https://docs.litellm.ai/) for API-based embeddings via `--embedder litellm`. Use the `--model` option to specify an embedding model. If not specified, a default model will be used. The current defaults are `all-MiniLM-L6-v2` for text, `google/vit-base-patch16-224` for images, and `laion/clap-htsat-fused` for audio, but these are subject to change in future releases.
 
 After embedding vectors are computed, the script will then project the high-dimensional vectors to 2D with [UMAP](https://umap-learn.readthedocs.io/en/latest/index.html).
 
@@ -60,7 +60,7 @@ Optionally, if you know what column your text data is in beforehand, you can spe
 embedding-atlas path_to_dataset.parquet --text text_column
 ```
 
-Similarly, you may supply the `--image` flag for image data, or the `--vector` flag for pre-computed embedding vectors.
+Similarly, you may supply the `--image` flag for image data, the `--audio` flag for audio data, or the `--vector` flag for pre-computed embedding vectors.
 :::
 
 If you've already pre-computed the embedding projection (e.g., by running your own embedding model and projecting them with UMAP), you may store them as two columns such as `projection_x` and `projection_y`, and pass them into `embedding-atlas` with the `--x` and `--y` flags:
@@ -83,12 +83,26 @@ For reproducible embedding visualizations, we recommend pre-computing both the e
 The `embedding_atlas` package provides utility functions to compute the embedding projections:
 
 ```python
-from embedding_atlas.projection import compute_text_projection
+from embedding_atlas.projection import compute_projection
 
-compute_text_projection(df, text="text_column",
+df = compute_projection(df, inputs="text_column", modality="text",
     x="projection_x", y="projection_y", neighbors="neighbors"
 )
 ```
+
+::: tip
+`compute_projection` cannot be called from within a running async event loop (e.g. Jupyter notebooks). Use `async_compute_projection` instead:
+
+```python
+from embedding_atlas.projection import async_compute_projection
+
+df = await async_compute_projection(df, inputs="text_column", modality="text",
+    x="projection_x", y="projection_y", neighbors="neighbors"
+)
+```
+
+`async_compute_projection` accepts the same arguments as `compute_projection`.
+:::
 
 ## MCP Support
 

--- a/packages/docs/widget.md
+++ b/packages/docs/widget.md
@@ -18,11 +18,17 @@ from embedding_atlas.widget import EmbeddingAtlasWidget
 EmbeddingAtlasWidget(df)
 
 # Compute text embedding and projection of the embedding
-from embedding_atlas.projection import compute_text_projection
+from embedding_atlas.projection import compute_projection
 
-compute_text_projection(df, text="description",
+df = compute_projection(df, inputs="description", modality="text",
     x="projection_x", y="projection_y", neighbors="neighbors"
 )
+
+# In async environments (e.g. Jupyter notebooks), use async_compute_projection instead:
+# from embedding_atlas.projection import async_compute_projection
+# df = await async_compute_projection(df, inputs="description", modality="text",
+#     x="projection_x", y="projection_y", neighbors="neighbors"
+# )
 
 # Create an Embedding Atlas widget with the pre-computed projection
 widget = EmbeddingAtlasWidget(df, text="description",


### PR DESCRIPTION
* New `compute_projection` function that auto-detects input modality (text, image, audio, vector) by inspecting Python types and binary data, then routes to the appropriate embedding backend and UMAP dimensionality reduction.

* Reads audio files via `soundfile`, resamples with `scipy`, and extracts embeddings through HuggingFace CLAP. Extends existing text and image embedding support to audio modality.

* CLI: `--text-projector` renamed to `--embedder`, `--sync` replaced by `--max-concurrency`, new `--audio` flag added.

* The old `compute_text_projection`, `compute_image_projection`, and `compute_vector_projection` functions are now removed.