### PR TITLE
fix: prevent embedding view hover tooltip from getting stuck

### DIFF
--- a/packages/component/src/lib/utils.ts
+++ b/packages/component/src/lib/utils.ts
@@ -48,8 +48,9 @@ export function throttleTooltip<T, U>(func: (input: T) => Promise<U>, isVisible:
       await func(input);
     } catch (e) {
       console.error(e);
+    } finally {
+      running = false;
     }
-    running = false;
     if (next !== undefined) {
       let v = next;
       next = undefined;


### PR DESCRIPTION
Closes #174

`throttleTooltip` sets a `running` flag before awaiting the hover callback and clears it after. The clear runs after the `try/catch`, not in a `finally`, so any uncaught error in the catch path (or rejection that isn't covered) leaves `running` stuck at `true`. Once that happens, every subsequent hover input just gets stored in `next` and never executes, which matches the reported symptom of the tooltip going silent after several quick hovers.

Move the reset into a `finally` block so it always runs.

### Testing
- `npm run check -w @embedding-atlas/component` passes (601 files, 0 errors)
- `npx prettier -c` on the file passes
- No behavior change in the happy path; only the unhandled error path is affected