### PR TITLE
fix: update labels when provided after mount

### DIFF
--- a/packages/component/src/lib/embedding_view/EmbeddingViewImpl.svelte
+++ b/packages/component/src/lib/embedding_view/EmbeddingViewImpl.svelte
@@ -243,7 +243,7 @@
   let pointSize = $derived(viewingParams.pointSize);
 
   let needsUpdateLabels = true;
-  let previousLabels: Label[] | null = $state(null);
+  let previousLabels: Label[] | null = null;
 
   $effect.pre(() => {
     if (labels !== previousLabels) {

--- a/packages/component/src/lib/embedding_view/EmbeddingViewImpl.svelte
+++ b/packages/component/src/lib/embedding_view/EmbeddingViewImpl.svelte
@@ -243,8 +243,14 @@
   let pointSize = $derived(viewingParams.pointSize);
 
   let needsUpdateLabels = true;
+  let previousLabels: Label[] | null = $state(null);
 
   $effect.pre(() => {
+    if (labels !== previousLabels) {
+      previousLabels = labels;
+      needsUpdateLabels = true;
+    }
+
     let needsRender = renderer?.setProps({
       mode: mode,
       colorScheme: colorScheme,
@@ -265,17 +271,18 @@
 
     if (needsRender) {
       setNeedsRender();
-      if (
-        (autoLabelEnabled !== false || labels != null) &&
-        needsUpdateLabels &&
-        renderer != null &&
-        data.x != null &&
-        data.x.length > 0 &&
-        defaultViewportState != null
-      ) {
-        needsUpdateLabels = false;
-        updateLabels(defaultViewportState);
-      }
+    }
+
+    if (
+      (autoLabelEnabled !== false || labels != null) &&
+      needsUpdateLabels &&
+      renderer != null &&
+      data.x != null &&
+      data.x.length > 0 &&
+      defaultViewportState != null
+    ) {
+      needsUpdateLabels = false;
+      updateLabels(defaultViewportState);
     }
   });
 


### PR DESCRIPTION
## Summary
- mark label layout dirty when the `labels` prop changes
- run label layout independently of renderer prop changes, so labels supplied after mount can render
- keep renderer render scheduling unchanged

Fixes #141

## Tests
- `npm run build -w @embedding-atlas/utils`
- `npm run check -w @embedding-atlas/component`
- `git diff --check origin/main..HEAD`
