### PR TITLE
docs: correct typos and grammar in READMEs and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ For the algorithm that automatically produces clusters and labels in the embeddi
 
 ## Development
 
-For development instructions, please visit <https://apple.github.io/embedding-atlas/develop.html>, or checkout `packages/docs/develop.md`.
+For development instructions, please visit <https://apple.github.io/embedding-atlas/develop.html>, or check out `packages/docs/develop.md`.
 
 ## License
 

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -1,6 +1,6 @@
 # Embedding Atlas
 
-A Python package that provides a command line tool to visualize a dataset with embeddings. It also includes a Python Notebook (e.g., Jupyter) widget and a Streamlit widget.
+A Python package that provides a command-line tool to visualize a dataset with embeddings. It also includes a Python notebook (e.g., Jupyter) widget and a Streamlit widget.
 
 - Documentation: https://apple.github.io/embedding-atlas
 - GitHub: https://github.com/apple/embedding-atlas
@@ -39,7 +39,7 @@ embedding-atlas huggingface_org/dataset_name
 
 ## Visualizing Embedding Projections
 
-To visual embedding projections, pre-compute the X and Y coordinates, and specify the column names with `--x` and `--y`, such as:
+To visualize embedding projections, pre-compute the X and Y coordinates, and specify the column names with `--x` and `--y`, such as:
 
 ```bash
 embedding-atlas path_to_dataset.parquet --x projection_x --y projection_y
@@ -68,4 +68,4 @@ If this column is specified, you'll be able to see nearest neighbors for a selec
 
 ## Local Development
 
-Launch Embedding Altas with a wine reviews dataset with `./start.sh` and the MNIST dataset with `./start_image.sh`.
+Launch Embedding Atlas with a wine reviews dataset with `./start.sh` and the MNIST dataset with `./start_image.sh`.

--- a/packages/docs/embedding-view-mosaic.md
+++ b/packages/docs/embedding-view-mosaic.md
@@ -1,9 +1,9 @@
 # EmbeddingViewMosaic
 
-The `embedding-atlas` package contains a component for displaying up to a few millions of points from an embedding with x and y coordinates.
+The `embedding-atlas` package contains a component for displaying up to a few million points from an embedding with x and y coordinates.
 The component connects to a [Mosaic](https://idl.uw.edu/mosaic/) coordinator and can display data for specified table and x, y coordinate columns.
 
-We also provide React and Svelte wrappers of the component to easily include it in your own application.
+We also provide React and Svelte wrappers for the component to easily include it in your own application.
 
 <p class="light-only"><img style="margin: 0 auto;" src="./public/assets/component-light.png" /></p>
 <p class="dark-only"><img style="margin: 0 auto;" src="./public/assets/component-dark.png" /></p>

--- a/packages/docs/embedding-view.md
+++ b/packages/docs/embedding-view.md
@@ -1,8 +1,8 @@
 # EmbeddingView
 
-The `embedding-atlas` package contains a component for displaying up to a few millions of points from an embedding with x and y coordinates.
+The `embedding-atlas` package contains a component for displaying up to a few million points from an embedding with x and y coordinates.
 
-We also provide React and Svelte wrappers of the component to easily include it in your own application.
+We also provide React and Svelte wrappers for the component to easily include it in your own application.
 
 <p class="light-only"><img style="margin: 0 auto;" src="./public/assets/component-light.png" /></p>
 <p class="dark-only"><img style="margin: 0 auto;" src="./public/assets/component-dark.png" /></p>

--- a/packages/docs/overview.md
+++ b/packages/docs/overview.md
@@ -25,12 +25,12 @@ You can use Embedding Atlas directly from this website by [loading your own data
 Embedding Atlas is released as two packages:
 
 - A Python package `embedding-atlas` that provides:
-  - A [command line tool](./tool.md) for launching Embedding Atlas from command line.
+  - A [command-line tool](./tool.md) for launching Embedding Atlas from the command line.
   - A [Python Notebook widget](./widget.md) for using Embedding Atlas in interactive Python notebooks.
   - A [Streamlit component](./streamlit.md) for using Embedding Atlas in Streamlit apps.
   - All of these approaches allow you to compute embeddings (with custom models) and projections.
 
-- An npm package `embedding-atlas` that exposes the user interface components as API so you can use them in your own applications. Below are the exposed components:
+- An npm package `embedding-atlas` that exposes the user interface components as APIs so you can use them in your own applications. Below are the exposed components:
   - [EmbeddingView](./embedding-view.md)
   - [EmbeddingViewMosaic](./embedding-view-mosaic.md)
   - [EmbeddingAtlas](./embedding-atlas.md)


### PR DESCRIPTION
### Description
This PR corrects several minor typos, spelling mistakes, and grammatical inconsistencies across the repository's READMEs and documentation files. 

### Changes

* **README.md**: Fixed `"checkout"` to `"check out"`.
* **packages/backend/README.md**:
  * Added missing hyphen to `"command-line tool"`.
  * Fixed typo `"Embedding Altas"` to `"Embedding Atlas"`.
  * Corrected spelling `"To visual embedding projections"` to `"To visualize embedding projections"`.
  * Normalized `"Python Notebook"` to lowercase `"Python notebook"`.
* **packages/docs/embedding-view-mosaic.md & packages/docs/embedding-view.md**:
  * Corrected `"a few millions of points"` to `"a few million points"`.
  * Rephrased `"wrappers of the component"` to `"wrappers for the component"`.
* **packages/docs/overview.md**:
  * Added missing hyphen to `"command-line tool"`.
  * Fixed `"from command line"` to `"from the command line"`.
  * Pluralized `"components as API"` to `"components as APIs"`.
  
### Solves
issue #205 
  
### Checklist

- [x] I have read the contribution guidelines.
- [x] My changes follow the style guidelines of this project.
- [x] I have performed a self-review of my own changes.