### PR TITLE
fix: exit -> return in export application codepath

### DIFF
--- a/packages/backend/embedding_atlas/cli.py
+++ b/packages/backend/embedding_atlas/cli.py
@@ -531,7 +531,7 @@ def main(
                 f.write(dataset.make_archive(static, export_metadata))
         else:
             dataset.export_to_folder(static, export_application, export_metadata)
-        exit(0)
+        return
 
     # Parse CORS configuration
     cors_config = False


### PR DESCRIPTION
This method can be called in a different context, you don't need to exit every time.