### PR TITLE
feat: support running umap by step

### DIFF
--- a/packages/component/src/lib/embedding_view/EmbeddingView.svelte
+++ b/packages/component/src/lib/embedding_view/EmbeddingView.svelte
@@ -31,6 +31,12 @@
 
   let derivedProperties = $derived(computeDerivedProperties(data));
 
+  // `categoryCount` only depends on the category array, which is effectively
+  // immutable for a given dataset. Cache it on the array reference so a streaming
+  // `data` (new object every frame, same category array) doesn't rescan it.
+  let cachedCategoryRef: Uint8Array | null = null;
+  let cachedCategoryCount = 1;
+
   function computeDerivedProperties(data: EmbeddingViewProps["data"]): {
     count: number;
     categoryCount: number;
@@ -39,7 +45,13 @@
   } {
     let categoryCount = 1;
     if (data.category != null) {
-      categoryCount = data.category.reduce((a, b) => Math.max(a, b), 0) + 1;
+      if (data.category === cachedCategoryRef) {
+        categoryCount = cachedCategoryCount;
+      } else {
+        categoryCount = data.category.reduce((a, b) => Math.max(a, b), 0) + 1;
+        cachedCategoryRef = data.category;
+        cachedCategoryCount = categoryCount;
+      }
     }
     let xCenter = median(data.x);
     let yCenter = median(data.y);

--- a/packages/component/src/lib/embedding_view/statistics.ts
+++ b/packages/component/src/lib/embedding_view/statistics.ts
@@ -2,27 +2,64 @@
 
 import quickselect from "quickselect";
 
+// Reusable scratch buffer for `median`, so repeated/streaming calls don't
+// allocate (and GC) a full copy of the input on every call.
+let medianScratch = new Float32Array(0);
+
 export function median(values: Float32Array): number {
-  let temp = new Float32Array(values);
-  let middleIndex = Math.floor(values.length / 2);
-  quickselect(temp as any, middleIndex);
-  return temp[middleIndex];
+  let n = values.length;
+  if (n === 0) {
+    return 0;
+  }
+  if (medianScratch.length < n) {
+    medianScratch = new Float32Array(n);
+  }
+  medianScratch.set(values);
+  let middleIndex = Math.floor(n / 2);
+  quickselect(medianScratch as any, middleIndex, 0, n - 1);
+  return medianScratch[middleIndex];
 }
 
 export function mean(values: Float32Array): number {
-  if (values.length == 0) {
+  let n = values.length;
+  if (n === 0) {
     return 0;
   }
-  return values.reduce((a, b) => a + b, 0) / values.length;
+  let sum = 0;
+  for (let i = 0; i < n; i++) {
+    sum += values[i];
+  }
+  return sum / n;
 }
 
 export function stdev(values: Float32Array): number {
-  if (values.length == 0) {
+  let n = values.length;
+  if (n === 0) {
     return 0;
   }
-  let m = mean(values);
-  return Math.sqrt(values.reduce((a, b) => a + (b - m) * (b - m)) / values.length);
+  // Single pass over the data: accumulate sum and sum-of-squares of values
+  // shifted by `values[0]` (the shift avoids catastrophic cancellation for
+  // large-magnitude coordinates while keeping it to one loop).
+  let shift = values[0];
+  let sum = 0;
+  let sumSq = 0;
+  for (let i = 0; i < n; i++) {
+    let d = values[i] - shift;
+    sum += d;
+    sumSq += d * d;
+  }
+  let m = sum / n;
+  let variance = sumSq / n - m * m;
+  return Math.sqrt(variance > 0 ? variance : 0);
 }
+
+// Reusable bin grid for `approximateDensity2D`, allocated lazily on first use so
+// merely importing this module costs no memory. Bins are centered on
+// `xBinStart`/`yBinStart`; points that fall outside the grid are sparse outliers
+// and are ignored (rather than clamped to the edge, which would manufacture a
+// spurious high-density edge).
+const DENSITY_GRID = 256;
+let densityGrid: Int32Array | null = null;
 
 export function approximateDensity2D(
   x: Float32Array,
@@ -31,19 +68,26 @@ export function approximateDensity2D(
   xBinStart: number = 0,
   yBinStart: number = 0,
 ): number {
-  let keyData = new ArrayBuffer(8);
-  let i32View = new Uint32Array(keyData);
-  let u64View = new BigUint64Array(keyData);
-  let map = new Map<bigint, number>();
-  for (let i = 0; i < x.length; i++) {
-    i32View[0] = Math.floor((x[i] - xBinStart) / binWidth);
-    i32View[1] = Math.floor((y[i] - yBinStart) / binWidth);
-    let key = u64View[0];
-    map.set(key, (map.get(key) ?? 0) + 1);
+  const g = DENSITY_GRID;
+  const h = g >> 1;
+  let grid = densityGrid;
+  if (grid == null) {
+    grid = new Int32Array(g * g); // freshly zeroed
+    densityGrid = grid;
+  } else {
+    grid.fill(0);
   }
-  let maxValue: number = 0;
-  for (let value of map.values()) {
-    maxValue = Math.max(value, maxValue);
+  let maxValue = 0;
+  for (let i = 0; i < x.length; i++) {
+    let bx = Math.floor((x[i] - xBinStart) / binWidth) + h;
+    let by = Math.floor((y[i] - yBinStart) / binWidth) + h;
+    if (bx < 0 || bx >= g || by < 0 || by >= g) {
+      continue; // outside the grid — ignore
+    }
+    let v = ++grid[by * g + bx];
+    if (v > maxValue) {
+      maxValue = v;
+    }
   }
   return maxValue / (binWidth * binWidth);
 }

--- a/packages/embedding-atlas/src/umap.ts
+++ b/packages/embedding-atlas/src/umap.ts
@@ -3,9 +3,11 @@
 export {
   createNNDescent,
   createUMAP,
+  createUMAPFromKNN,
   type NNDescentOptions,
   type NNDescentQueryResult,
   type NNDescentResult,
   type UMAP,
+  type UMAPFromKNNOptions,
   type UMAPOptions,
 } from "@embedding-atlas/umap-wasm";

--- a/packages/umap/umap-wasm/index.d.ts
+++ b/packages/umap/umap-wasm/index.d.ts
@@ -61,8 +61,11 @@ export interface UMAPOptions {
   /** The input distance metric */
   metric?: "euclidean" | "cosine";
 
-  /** The initialization method. By default we use spectral initialization. */
+  /** The initialization method. Default: "spectral" (momentum forces "random"). */
   initializeMethod?: "spectral" | "random";
+
+  /** The optimizer. Default: "sgd". "momentum" gives better global structure. */
+  optimizer?: "sgd" | "momentum";
 
   localConnectivity?: number;
   mixRatio?: number;
@@ -84,6 +87,7 @@ export interface UMAPOptions {
   gpu?: boolean;
 }
 
+/** A stateful, resumable UMAP instance. */
 export interface UMAP {
   /** The input dimension */
   readonly inputDim: number;
@@ -91,28 +95,61 @@ export interface UMAP {
   /** The output dimension */
   readonly outputDim: number;
 
+  /** The number of epochs run so far. During an in-flight `step`/`run` this
+   *  returns the last settled value (the count is refreshed when the op settles). */
+  readonly epoch: number;
+
   /**
-   * Get the current embedding.
-   * Returns an empty Float32Array before `run()` is called.
+   * Get the current embedding. Valid immediately after `createUMAP` (eager
+   * setup, epoch 0) and refreshed by `run`/`step`.
+   *
+   * Safe to read during an in-flight `step`/`run`: it returns the last settled
+   * snapshot rather than reading the (borrowed) wasm instance, so it never
+   * throws even when polled from a requestAnimationFrame loop.
+   *
+   * Note: returns a reused buffer — copy it (e.g. `new Float32Array(embedding)`)
+   * if you need a stable snapshot across subsequent reads.
    */
   readonly embedding: Float32Array;
 
-  /**
-   * Get the KNN indices from the neighbor graph.
-   * Returns an empty Int32Array before `run()` is called.
-   */
+  /** The KNN indices from the neighbor graph. Valid immediately (eager setup);
+   *  the graph is immutable, so it is snapshotted at construction and is safe to
+   *  access at any time, including during an in-flight `step`/`run`. */
   readonly knnIndices: Int32Array;
 
-  /**
-   * Get the KNN distances from the neighbor graph.
-   * Returns an empty Float32Array before `run()` is called.
-   */
+  /** The KNN distances from the neighbor graph. Valid immediately (eager setup);
+   *  snapshotted at construction and safe to access during an in-flight `step`/`run`. */
   readonly knnDistances: Float32Array;
 
   /**
-   * Run the UMAP algorithm to completion.
+   * Anneal the layout to completion: linear learning-rate decay from the current
+   * `learningRate` down to 0 over the default horizon, continuing from the current
+   * epoch. The peak is the live `learningRate` (from `createUMAP` options or the
+   * last `setParameters`).
    */
   run(): Promise<void>;
+
+  /**
+   * Advance the layout by `nEpochs` at the current `learningRate`, held flat (no
+   * decay). Intended for interactive/real-time stepping. Default: 1 epoch.
+   */
+  step(nEpochs?: number): Promise<void>;
+
+  /**
+   * Update live parameters. `learningRate` is used flat by `step` and as the
+   * decay peak by `run`. `minDist`/`spread` re-fit the output curve. Safe to call
+   * during an in-flight `step`/`run` — the update is queued and applied in order,
+   * once any in-flight/queued sections settle.
+   */
+  setParameters(
+    params: Pick<UMAPOptions, "learningRate" | "repulsionStrength" | "negativeSampleRate" | "minDist" | "spread">,
+  ): void;
+
+  /** Switch optimizer. Resets the velocity buffer. Queued; runs in order after any in-flight `step`/`run`. */
+  setOptimizer(optimizer: "sgd" | "momentum"): void;
+
+  /** Re-initialize the embedding and restart from epoch 0. Default: "spectral". Queued; runs in order after any in-flight `step`/`run`. */
+  reset(method?: "spectral" | "random"): void;
 
   /** Destroy the instance and release resources */
   destroy(): void;
@@ -132,4 +169,42 @@ export function createUMAP(
   outputDim: number,
   data: Float32Array,
   options?: UMAPOptions,
+): Promise<UMAP>;
+
+/**
+ * Options for {@link createUMAPFromKNN}. The kNN-computation knobs (`metric`,
+ * `nNeighbors`) do not apply when the graph is supplied directly.
+ */
+export type UMAPFromKNNOptions = Omit<UMAPOptions, "metric" | "nNeighbors">;
+
+/**
+ * Build a UMAP instance from a precomputed kNN graph, skipping the internal
+ * nearest-neighbor search. No high-dimensional data is needed — once the graph
+ * exists, UMAP uses only it. The returned instance is the same {@link UMAP} as
+ * {@link createUMAP} (its `inputDim` is reported as 0 since no vectors were given).
+ *
+ * `knnIndices` and `knnDistances` are row-major with `count * k` elements; row `i`
+ * lists the neighbors of point `i` sorted by ascending distance. The point itself
+ * may appear in column 0 (distance 0) or be omitted — this is detected and
+ * normalized per row.
+ *
+ * Caller's contract (the graph is not validated beyond an index-range check, and
+ * bad input degrades silently rather than throwing): every index must be valid
+ * (`0 <= idx < count`); point `i` may appear in its own row at most once; distances
+ * must be finite (a `NaN` propagates to a `NaN` embedding); and the neighbor count
+ * must be uniform across rows — the effective `k` is the per-row minimum, so a
+ * single short row trims every row down to its length.
+ *
+ * @param count the number of data points
+ * @param outputDim the output dimension
+ * @param knnIndices row-major neighbor indices, length count * k
+ * @param knnDistances row-major neighbor distances, length count * k (same shape)
+ * @param options layout options
+ */
+export function createUMAPFromKNN(
+  count: number,
+  outputDim: number,
+  knnIndices: Int32Array,
+  knnDistances: Float32Array,
+  options?: UMAPFromKNNOptions,
 ): Promise<UMAP>;

--- a/packages/umap/umap-wasm/index.js
+++ b/packages/umap/umap-wasm/index.js
@@ -1,4 +1,4 @@
-import { UMAPBuilder, NNDescentBuilder, default as init } from "./pkg/umap_wasm.js";
+import { NNDescentBuilder, UMAPBuilder, UMAPFromKnnBuilder, default as init } from "./pkg/umap_wasm.js";
 
 /**
  * Initialize a UMAP instance.
@@ -25,11 +25,159 @@ export async function createUMAP(count, inputDim, outputDim, data, options = {})
   if (options.localConnectivity != null) builder = builder.localConnectivity(options.localConnectivity);
   if (options.mixRatio != null) builder = builder.mixRatio(options.mixRatio);
   if (options.initializeMethod != null) builder = builder.initMethod(options.initializeMethod);
+  if (options.optimizer != null) builder = builder.optimizer(options.optimizer);
   if (options.seed != null) builder = builder.randomState(BigInt(options.seed));
   if (options.progress != null) builder = builder.progress(options.progress);
   if (options.gpu) builder = builder.gpu(true);
 
-  let result = null;
+  // Eager setup: builds the graph + initial embedding (so `embedding` is valid
+  // immediately at epoch 0). `run`/`step` advance the layout from there.
+  const umap = await builder.build();
+
+  return wrapUmap(umap, count, inputDim, outputDim);
+}
+
+/**
+ * Build a UMAP instance from a precomputed kNN graph, skipping the internal
+ * nearest-neighbor search. No high-dimensional data is needed.
+ *
+ * `knnIndices`/`knnDistances` are row-major (`count * k`); row `i` lists point
+ * `i`'s neighbors sorted by ascending distance. Caller's contract (the graph is
+ * not validated beyond an index-range check, and bad input degrades silently
+ * rather than throwing): every index is valid (`0 <= idx < count`); point `i`
+ * appears in its own row at most once (self may be column 0 with distance 0, or
+ * omitted); distances are finite (a `NaN` propagates to a `NaN` embedding); and the
+ * neighbor count is uniform across rows (the effective `k` is the per-row minimum,
+ * so one short row trims every row).
+ *
+ * @param {number} count the number of data points
+ * @param {number} outputDim the output dimension
+ * @param {Int32Array} knnIndices row-major neighbor indices (count * k)
+ * @param {Float32Array} knnDistances row-major neighbor distances (count * k)
+ * @param {object} [options] layout options (UMAPOptions minus metric/nNeighbors)
+ * @returns {Promise<UMAP>}
+ */
+export async function createUMAPFromKNN(count, outputDim, knnIndices, knnDistances, options = {}) {
+  await init();
+
+  let builder = new UMAPFromKnnBuilder(knnIndices, knnDistances, count, outputDim);
+
+  if (options.minDist != null) builder = builder.minDist(options.minDist);
+  if (options.spread != null) builder = builder.spread(options.spread);
+  if (options.nEpochs != null) builder = builder.nEpochs(options.nEpochs);
+  if (options.learningRate != null) builder = builder.learningRate(options.learningRate);
+  if (options.negativeSampleRate != null) builder = builder.negativeSampleRate(options.negativeSampleRate);
+  if (options.repulsionStrength != null) builder = builder.repulsionStrength(options.repulsionStrength);
+  if (options.localConnectivity != null) builder = builder.localConnectivity(options.localConnectivity);
+  if (options.mixRatio != null) builder = builder.mixRatio(options.mixRatio);
+  if (options.initializeMethod != null) builder = builder.initMethod(options.initializeMethod);
+  if (options.optimizer != null) builder = builder.optimizer(options.optimizer);
+  if (options.seed != null) builder = builder.randomState(BigInt(options.seed));
+  if (options.progress != null) builder = builder.progress(options.progress);
+  if (options.gpu) builder = builder.gpu(true);
+
+  const umap = await builder.build();
+
+  // No high-dim data was supplied, so the input dimension is unknown (reported as 0).
+  return wrapUmap(umap, count, 0, outputDim);
+}
+
+/**
+ * A tiny async sequencer that serializes access to a resource which can only be
+ * touched while no async section holds it.
+ *
+ * `step`/`run` are async wasm methods: wasm-bindgen keeps a mutable borrow on the
+ * instance across their GPU-readback await, so touching the instance while one is
+ * in flight throws ("recursive use of an object detected", or for free()
+ * "attempted to take ownership ... while borrowed").
+ *
+ * - `enqueue(fn)` runs `fn` as an exclusive section, serialized in submission
+ *   order so overlapping `step`/`run` calls queue rather than overlap the wasm
+ *   borrow. The chain survives a rejected section, so a later queued one — notably
+ *   `destroy()`'s `free()` — still runs.
+ * - `runOrQueue(label, action)` is for synchronous wasm ops (setParameters/reset/
+ *   free): it runs `action` immediately when nothing is queued or running — so the
+ *   effect is observable at once — otherwise queues it behind the in-flight section
+ *   (never mid-borrow). Fire-and-forget, so a queued rejection is logged.
+ * - `running` is true only while a section is actually executing (the borrow is
+ *   held); getters consult it to serve a snapshot instead of reading the borrowed
+ *   instance.
+ */
+function createSequencer() {
+  let running = false;
+  let pending = 0; // queued-or-running sections
+  let tail = Promise.resolve(); // serial chain; sections run in submission order
+
+  function enqueue(fn) {
+    pending++;
+    const result = tail.then(async () => {
+      running = true;
+      try {
+        return await fn();
+      } finally {
+        running = false;
+        pending--;
+      }
+    });
+    // Keep the chain alive past a rejection so later sections (e.g. free) run.
+    tail = result.then(
+      () => {},
+      () => {},
+    );
+    return result;
+  }
+
+  function runOrQueue(label, action) {
+    if (pending === 0) {
+      action();
+    } else {
+      enqueue(action).catch((e) => console.error(`UMAP: ${label} failed`, e));
+    }
+  }
+
+  return {
+    get running() {
+      return running;
+    },
+    enqueue,
+    runOrQueue,
+  };
+}
+
+/**
+ * Wrap a built wasm `Umap` instance in the stable JS UMAP interface. A
+ * {@link createSequencer} mediates all wasm access so callers can safely step in
+ * a requestAnimationFrame loop while tuning parameters, reading the embedding,
+ * or tearing the instance down. Shared by `createUMAP` and `createUMAPFromKNN`.
+ * @param {import("./pkg/umap_wasm.js").Umap} umap
+ * @param {number} count
+ * @param {number} inputDim
+ * @param {number} outputDim
+ * @returns {UMAP}
+ */
+function wrapUmap(umap, count, inputDim, outputDim) {
+  const seq = createSequencer();
+  let destroyed = false;
+
+  // JS-side snapshots served while a step/run holds the wasm borrow. All are
+  // primed now, at construction, while idle. epoch and embedding change over
+  // time, so they are also refreshed on later idle reads; the kNN graph is
+  // immutable, so capturing it once here is enough (and means the getters can't
+  // return an empty array when first read during an in-flight step).
+  const outBuf = new Float32Array(count * outputDim);
+  umap.copyEmbeddingInto(outBuf);
+  let lastEpoch = umap.epoch;
+  const knnIndicesSnapshot = umap.knnIndices;
+  const knnDistancesSnapshot = umap.knnDistances;
+
+  // Merged target for setParameters (supports partial updates; applied via the
+  // sequencer so it lands immediately when idle, else once the in-flight/queued
+  // step/run settles).
+  let desiredParams = null;
+  function applyDesiredParams() {
+    const p = desiredParams;
+    umap.setParameters(p.learningRate, p.repulsionStrength, p.negativeSampleRate, p.minDist, p.spread);
+  }
 
   return {
     get inputDim() {
@@ -38,24 +186,49 @@ export async function createUMAP(count, inputDim, outputDim, data, options = {})
     get outputDim() {
       return outputDim;
     },
+    get epoch() {
+      if (destroyed) return 0;
+      if (!seq.running) lastEpoch = umap.epoch;
+      return lastEpoch;
+    },
     get embedding() {
-      return result?.embedding ?? new Float32Array(0);
+      if (destroyed) return new Float32Array(0);
+      if (!seq.running) umap.copyEmbeddingInto(outBuf);
+      return outBuf;
     },
     get knnIndices() {
-      return result?.knnIndices ?? new Int32Array(0);
+      return destroyed ? new Int32Array(0) : knnIndicesSnapshot;
     },
     get knnDistances() {
-      return result?.knnDistances ?? new Float32Array(0);
+      return destroyed ? new Float32Array(0) : knnDistancesSnapshot;
     },
     async run() {
-      if (result) return;
-      result = await builder.build();
+      if (destroyed) return;
+      await seq.enqueue(() => umap.run());
+    },
+    async step(nEpochs = 1) {
+      if (destroyed) return;
+      await seq.enqueue(() => umap.step(nEpochs));
+    },
+    setParameters(params = {}) {
+      if (destroyed) return;
+      desiredParams = { ...(desiredParams ?? {}), ...params };
+      seq.runOrQueue("setParameters", applyDesiredParams);
+    },
+    setOptimizer(optimizer) {
+      if (destroyed) return;
+      seq.runOrQueue("setOptimizer", () => umap.setOptimizer(optimizer));
+    },
+    reset(method = "spectral") {
+      if (destroyed) return;
+      seq.runOrQueue("reset", () => umap.reset(method));
     },
     destroy() {
-      if (result) {
-        result.free();
-        result = null;
-      }
+      if (destroyed) return;
+      destroyed = true;
+      // Frees now if idle, else after any queued sections settle (never on a
+      // borrowed instance).
+      seq.runOrQueue("free", () => umap.free());
     },
   };
 }

--- a/packages/umap/umap-wasm/src/lib.rs
+++ b/packages/umap/umap-wasm/src/lib.rs
@@ -1,8 +1,11 @@
 use ndarray::Array2;
 use wasm_bindgen::prelude::*;
 
+use nndescent::rng::Xoshiro256StarStar;
 use nndescent::NNDescent;
-use umap::{Init, Umap};
+use umap::graph::CsrMatrix;
+use umap::spectral::{noisy_scale_coords, random_layout, spectral_layout};
+use umap::{find_ab_params, Init, Optimizer, Umap as UmapCore, UmapOptimizer};
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -79,10 +82,11 @@ pub struct UMAPBuilder {
     local_connectivity: f32,
     set_op_mix_ratio: f32,
     init: Init,
+    optimizer: Optimizer,
     random_state: Option<u64>,
     verbose: bool,
     gpu: bool,
-    progress: Option<nndescent::ProgressCallback>,
+    progress: Option<js_sys::Function>,
 }
 
 #[wasm_bindgen]
@@ -111,6 +115,7 @@ impl UMAPBuilder {
             local_connectivity: 1.0,
             set_op_mix_ratio: 1.0,
             init: Init::Spectral,
+            optimizer: Optimizer::Sgd,
             random_state: None,
             verbose: false,
             gpu: false,
@@ -187,11 +192,21 @@ impl UMAPBuilder {
     }
 
     /// Initialization method: "spectral" or "random". Default: "spectral".
+    /// (Momentum forces random init regardless; see the core builder.)
     #[wasm_bindgen(js_name = "initMethod")]
     pub fn init_method(mut self, method: &str) -> UMAPBuilder {
         self.init = match method {
             "random" => Init::Random,
             _ => Init::Spectral,
+        };
+        self
+    }
+
+    /// Optimizer: "sgd" (default) or "momentum".
+    pub fn optimizer(mut self, optimizer: &str) -> UMAPBuilder {
+        self.optimizer = match optimizer {
+            "momentum" => Optimizer::Momentum,
+            _ => Optimizer::Sgd,
         };
         self
     }
@@ -219,15 +234,19 @@ impl UMAPBuilder {
     /// Set a progress callback: `(progress: number, stage: string) => void`.
     /// `progress` is in [0, 1], `stage` describes the current processing phase.
     pub fn progress(mut self, callback: js_sys::Function) -> UMAPBuilder {
-        self.progress = Some(js_to_progress_callback(callback));
+        self.progress = Some(callback);
         self
     }
 
-    /// Run UMAP and return the embedding result.
-    pub async fn build(self) -> Result<UMAPResult, JsError> {
+    /// Build the graph + initial embedding (eager) and return a stateful [`Umap`].
+    ///
+    /// The embedding and kNN graph are valid immediately at epoch 0; call
+    /// [`Umap::run`] to anneal to completion or [`Umap::step`] to advance
+    /// interactively.
+    pub async fn build(self) -> Result<Umap, JsError> {
         let array = parse_data(&self.data, self.n_rows, self.n_cols)?;
 
-        let mut builder = Umap::builder(&array)
+        let mut builder = UmapCore::builder(&array)
             .n_components(self.n_components)
             .n_neighbors(self.n_neighbors)
             .min_dist(self.min_dist)
@@ -239,6 +258,7 @@ impl UMAPBuilder {
             .local_connectivity(self.local_connectivity)
             .set_op_mix_ratio(self.set_op_mix_ratio)
             .init_method(self.init)
+            .optimizer(self.optimizer)
             .gpu(self.gpu)
             .verbose(self.verbose);
         if let Some(n) = self.n_epochs {
@@ -247,45 +267,171 @@ impl UMAPBuilder {
         if let Some(seed) = self.random_state {
             builder = builder.random_state(seed);
         }
-        if let Some(cb) = self.progress {
-            builder = builder.progress(cb);
+        // Report progress during the (eager) setup using a clone of the callback;
+        // the original is retained for run()/step().
+        if let Some(cb) = &self.progress {
+            builder = builder.progress(js_to_progress_callback(cb.clone()));
         }
 
-        let result = builder
-            .build_async()
+        let setup = builder
+            .setup_async()
             .await
             .map_err(|e| JsError::new(&e.to_string()))?;
-        let n_rows = result.embedding.nrows();
-        let n_components = result.embedding.ncols();
-        let n_neighbors = result.knn_indices.ncols();
-        Ok(UMAPResult {
-            embedding: result.embedding.into_raw_vec_and_offset().0,
-            knn_indices: result.knn_indices.into_raw_vec_and_offset().0,
-            knn_distances: result.knn_distances.into_raw_vec_and_offset().0,
+
+        let n_rows = setup.optimizer.embedding().nrows();
+        let n_components = setup.optimizer.embedding().ncols();
+        let n_neighbors_out = setup.knn_indices.ncols();
+
+        Ok(Umap {
+            optimizer: setup.optimizer,
+            graph: setup.graph,
+            knn_indices: setup.knn_indices.into_raw_vec_and_offset().0,
+            knn_distances: setup.knn_distances.into_raw_vec_and_offset().0,
+            n_neighbors_out,
             n_rows,
             n_components,
-            n_neighbors,
+            min_dist: self.min_dist,
+            spread: self.spread,
+            seed: self.random_state,
+            n_epochs: setup.n_epochs,
+            progress: self.progress,
+            verbose: self.verbose,
         })
     }
 }
 
-/// Result of a UMAP embedding.
+/// A stateful, resumable UMAP. The embedding/kNN are valid immediately after
+/// [`UMAPBuilder::build`] (eager setup); `run`/`step` advance the layout in place.
 #[wasm_bindgen]
-pub struct UMAPResult {
-    embedding: Vec<f32>,
+pub struct Umap {
+    optimizer: UmapOptimizer,
+    /// Pruned fuzzy graph, retained for spectral re-initialization in `reset`.
+    graph: CsrMatrix,
     knn_indices: Vec<i32>,
     knn_distances: Vec<f32>,
+    n_neighbors_out: usize,
     n_rows: usize,
     n_components: usize,
-    n_neighbors: usize,
+    min_dist: f32,
+    spread: f32,
+    seed: Option<u64>,
+    n_epochs: usize,
+    progress: Option<js_sys::Function>,
+    verbose: bool,
 }
 
 #[wasm_bindgen]
-impl UMAPResult {
-    /// Embedding coordinates as a flat Float32Array (row-major, n_rows x n_components).
+impl Umap {
+    /// Anneal the layout to completion: linear learning-rate decay from the
+    /// current `learningRate` down to 0 over the default horizon, continuing from
+    /// the current epoch. Reports progress over the optimization stage.
+    pub async fn run(&mut self) -> Result<(), JsError> {
+        let progress = self.progress.clone().map(js_to_progress_callback);
+        let mut logger = umap::Logger::new(self.verbose, progress, umap::UMAP_STAGES);
+        logger.push_stage_with_message(umap::STAGE_OPTIMIZATION, "Optimizing layout...");
+        self.optimizer.run_to(self.n_epochs, &mut logger).await;
+        logger.pop_stage();
+        Ok(())
+    }
+
+    /// Advance the layout by `n_epochs` at the current learning rate (no decay) —
+    /// intended for interactive/real-time stepping.
+    pub async fn step(&mut self, n_epochs: usize) {
+        self.optimizer.step(n_epochs).await;
+    }
+
+    /// Update live parameters. `min_dist`/`spread` re-fit the a/b curve, but only
+    /// when their (clamped) values actually change — callers typically re-send the
+    /// merged parameter set on every partial update, and the fit is not cheap.
+    /// `spread` is clamped to `>= min_dist` to avoid degenerate curves. Any argument
+    /// may be `null`/`undefined` to leave it unchanged.
+    #[wasm_bindgen(js_name = "setParameters")]
+    pub fn set_parameters(
+        &mut self,
+        learning_rate: Option<f32>,
+        repulsion_strength: Option<f32>,
+        negative_sample_rate: Option<f32>,
+        min_dist: Option<f32>,
+        spread: Option<f32>,
+    ) {
+        let mut p = self.optimizer.params();
+        if let Some(lr) = learning_rate {
+            p.alpha = lr;
+        }
+        if let Some(rs) = repulsion_strength {
+            p.gamma = rs;
+        }
+        if let Some(nsr) = negative_sample_rate {
+            p.negative_sample_rate = nsr;
+        }
+        if min_dist.is_some() || spread.is_some() {
+            let (prev_min_dist, prev_spread) = (self.min_dist, self.spread);
+            if let Some(md) = min_dist {
+                self.min_dist = md;
+            }
+            if let Some(sp) = spread {
+                self.spread = sp;
+            }
+            // Clamp spread >= min_dist (low spread triggers an a≈0 explosion /
+            // a≈830 collapse in find_ab_params).
+            if self.spread < self.min_dist {
+                self.spread = self.min_dist;
+            }
+            // Re-fit the a/b curve only if the clamped values changed. `p` already
+            // carries the current a/b, so an unchanged curve is left as-is — this
+            // skips a redundant find_ab_params on every partial setParameters.
+            if self.min_dist != prev_min_dist || self.spread != prev_spread {
+                let (a, b) = find_ab_params(self.spread, self.min_dist);
+                p.a = a as f32;
+                p.b = b as f32;
+            }
+        }
+        self.optimizer.set_params(p);
+    }
+
+    /// Switch optimizer: "sgd" or "momentum". Resets the velocity buffer.
+    #[wasm_bindgen(js_name = "setOptimizer")]
+    pub fn set_optimizer(&mut self, optimizer: &str) {
+        let opt = match optimizer {
+            "momentum" => Optimizer::Momentum,
+            _ => Optimizer::Sgd,
+        };
+        self.optimizer.set_optimizer(opt);
+    }
+
+    /// Re-initialize the embedding and restart the schedule from epoch 0.
+    /// `method` is "spectral" (uses the retained graph) or "random".
+    pub fn reset(&mut self, method: &str) {
+        let mut rng = match self.seed {
+            Some(s) => Xoshiro256StarStar::seed_from_u64(s),
+            None => Xoshiro256StarStar::seed_from_os(),
+        };
+        let embedding = match method {
+            "spectral" => {
+                let mut emb = spectral_layout(&self.graph, self.n_components, &mut rng);
+                noisy_scale_coords(&mut emb, &mut rng, 10.0, 0.0001);
+                emb
+            }
+            _ => random_layout(self.n_rows, self.n_components, &mut rng),
+        };
+        self.optimizer.reinit_embedding(embedding);
+    }
+
+    /// Copy the current embedding into `out` (length n_rows * n_components). The
+    /// JS-side typed array is updated in place on return.
+    #[wasm_bindgen(js_name = "copyEmbeddingInto")]
+    pub fn copy_embedding_into(&self, out: &mut [f32]) {
+        self.optimizer.copy_embedding_into(out);
+    }
+
+    /// Embedding coordinates as a flat Float32Array (row-major).
     #[wasm_bindgen(getter)]
     pub fn embedding(&self) -> Vec<f32> {
-        self.embedding.clone()
+        self.optimizer
+            .embedding()
+            .as_slice()
+            .map(|s| s.to_vec())
+            .unwrap_or_default()
     }
 
     /// KNN indices as a flat Int32Array (row-major, n_rows x n_neighbors).
@@ -312,10 +458,276 @@ impl UMAPResult {
         self.n_components
     }
 
-    /// Number of neighbors per point.
+    /// Number of neighbors per point in the kNN graph.
     #[wasm_bindgen(getter, js_name = "nNeighbors")]
     pub fn n_neighbors(&self) -> usize {
-        self.n_neighbors
+        self.n_neighbors_out
+    }
+
+    /// The number of epochs run so far.
+    #[wasm_bindgen(getter)]
+    pub fn epoch(&self) -> f64 {
+        self.optimizer.current_epoch() as f64
+    }
+}
+
+// ---------------------------------------------------------------------------
+// UMAP from a precomputed kNN graph
+// ---------------------------------------------------------------------------
+
+/// Builder for UMAP from a precomputed kNN graph (skips NNDescent — no
+/// high-dimensional data needed).
+///
+/// Usage (JS):
+/// ```js
+/// const result = new UMAPFromKnnBuilder(knnIndices, knnDistances, 1000, 2)
+///   .minDist(0.1)
+///   .randomState(42)
+///   .build();
+/// ```
+///
+/// `knnIndices`/`knnDistances` are row-major (n_rows * k); row i lists the
+/// neighbors of point i sorted by ascending distance. The point itself may appear
+/// in column 0 (distance 0) or be omitted — detected and normalized per row.
+///
+/// The caller must supply a well-formed graph (not validated beyond an index-range
+/// check): every index in `[0, n_rows)`, at most one self-entry per row, finite
+/// distances (no `NaN`), and a uniform real-neighbor count across rows. Violations
+/// degrade silently — a `NaN` distance yields a `NaN` embedding, and one short row
+/// trims every row to its length.
+#[wasm_bindgen]
+pub struct UMAPFromKnnBuilder {
+    knn_indices: Vec<i32>,
+    knn_distances: Vec<f32>,
+    n_rows: usize,
+    n_components: usize,
+    // Optional parameters with defaults (no metric / n_neighbors: k comes from the graph)
+    min_dist: f32,
+    spread: f32,
+    n_epochs: Option<usize>,
+    learning_rate: f32,
+    negative_sample_rate: usize,
+    repulsion_strength: f32,
+    local_connectivity: f32,
+    set_op_mix_ratio: f32,
+    init: Init,
+    optimizer: Optimizer,
+    random_state: Option<u64>,
+    verbose: bool,
+    gpu: bool,
+    progress: Option<js_sys::Function>,
+}
+
+#[wasm_bindgen]
+impl UMAPFromKnnBuilder {
+    /// Create a new builder from a precomputed kNN graph.
+    ///
+    /// @param knn_indices - Flat Int32Array, row-major (n_rows * k).
+    /// @param knn_distances - Flat Float32Array, row-major (n_rows * k).
+    /// @param n_rows - Number of data points.
+    /// @param n_components - Target embedding dimensions (typically 2).
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        knn_indices: &[i32],
+        knn_distances: &[f32],
+        n_rows: usize,
+        n_components: usize,
+    ) -> UMAPFromKnnBuilder {
+        UMAPFromKnnBuilder {
+            knn_indices: knn_indices.to_vec(),
+            knn_distances: knn_distances.to_vec(),
+            n_rows,
+            n_components,
+            min_dist: 0.1,
+            spread: 1.0,
+            n_epochs: None,
+            learning_rate: 1.0,
+            negative_sample_rate: 5,
+            repulsion_strength: 1.0,
+            local_connectivity: 1.0,
+            set_op_mix_ratio: 1.0,
+            init: Init::Spectral,
+            optimizer: Optimizer::Sgd,
+            random_state: None,
+            verbose: false,
+            gpu: false,
+            progress: None,
+        }
+    }
+
+    /// Minimum distance between points in embedding. Default: 0.1.
+    #[wasm_bindgen(js_name = "minDist")]
+    pub fn min_dist(mut self, d: f32) -> UMAPFromKnnBuilder {
+        self.min_dist = d;
+        self
+    }
+
+    /// Effective scale of embedded points. Default: 1.0.
+    pub fn spread(mut self, s: f32) -> UMAPFromKnnBuilder {
+        self.spread = s;
+        self
+    }
+
+    /// Number of optimization epochs. Default: auto.
+    #[wasm_bindgen(js_name = "nEpochs")]
+    pub fn n_epochs(mut self, n: usize) -> UMAPFromKnnBuilder {
+        self.n_epochs = Some(n);
+        self
+    }
+
+    /// Initial learning rate. Default: 1.0.
+    #[wasm_bindgen(js_name = "learningRate")]
+    pub fn learning_rate(mut self, lr: f32) -> UMAPFromKnnBuilder {
+        self.learning_rate = lr;
+        self
+    }
+
+    /// Negative samples per positive sample. Default: 5.
+    #[wasm_bindgen(js_name = "negativeSampleRate")]
+    pub fn negative_sample_rate(mut self, r: usize) -> UMAPFromKnnBuilder {
+        self.negative_sample_rate = r;
+        self
+    }
+
+    /// Weight of repulsive force. Default: 1.0.
+    #[wasm_bindgen(js_name = "repulsionStrength")]
+    pub fn repulsion_strength(mut self, s: f32) -> UMAPFromKnnBuilder {
+        self.repulsion_strength = s;
+        self
+    }
+
+    /// Local connectivity constraint. Default: 1.0.
+    #[wasm_bindgen(js_name = "localConnectivity")]
+    pub fn local_connectivity(mut self, c: f32) -> UMAPFromKnnBuilder {
+        self.local_connectivity = c;
+        self
+    }
+
+    /// Interpolation between fuzzy union and intersection. Default: 1.0.
+    #[wasm_bindgen(js_name = "mixRatio")]
+    pub fn mix_ratio(mut self, r: f32) -> UMAPFromKnnBuilder {
+        self.set_op_mix_ratio = r;
+        self
+    }
+
+    /// Initialization method: "spectral" or "random". Default: "spectral".
+    #[wasm_bindgen(js_name = "initMethod")]
+    pub fn init_method(mut self, method: &str) -> UMAPFromKnnBuilder {
+        self.init = match method {
+            "random" => Init::Random,
+            _ => Init::Spectral,
+        };
+        self
+    }
+
+    /// Optimizer: "sgd" (default) or "momentum".
+    pub fn optimizer(mut self, optimizer: &str) -> UMAPFromKnnBuilder {
+        self.optimizer = match optimizer {
+            "momentum" => Optimizer::Momentum,
+            _ => Optimizer::Sgd,
+        };
+        self
+    }
+
+    /// Random seed for reproducibility. Default: None (random).
+    #[wasm_bindgen(js_name = "randomState")]
+    pub fn random_state(mut self, seed: i64) -> UMAPFromKnnBuilder {
+        self.random_state = parse_seed(seed);
+        self
+    }
+
+    /// Enable verbose output. Default: false.
+    pub fn verbose(mut self, v: bool) -> UMAPFromKnnBuilder {
+        self.verbose = v;
+        self
+    }
+
+    /// Enable GPU acceleration via WebGPU for the layout optimization. Default: false.
+    pub fn gpu(mut self, g: bool) -> UMAPFromKnnBuilder {
+        self.gpu = g;
+        self
+    }
+
+    /// Set a progress callback: `(progress: number, stage: string) => void`.
+    pub fn progress(mut self, callback: js_sys::Function) -> UMAPFromKnnBuilder {
+        self.progress = Some(callback);
+        self
+    }
+
+    /// Build the graph + initial embedding (eager) and return a stateful [`Umap`].
+    pub async fn build(self) -> Result<Umap, JsError> {
+        if self.n_rows == 0 {
+            return Err(JsError::new("nRows must be > 0"));
+        }
+        if self.knn_indices.len() != self.knn_distances.len() {
+            return Err(JsError::new(
+                "knnIndices and knnDistances must have equal length",
+            ));
+        }
+        if self.knn_indices.len() % self.n_rows != 0 {
+            return Err(JsError::new(&format!(
+                "knn length {} is not divisible by nRows {}",
+                self.knn_indices.len(),
+                self.n_rows
+            )));
+        }
+        let k = self.knn_indices.len() / self.n_rows;
+        if k < 1 {
+            return Err(JsError::new("each point must have at least one neighbor"));
+        }
+
+        let idx = Array2::from_shape_vec((self.n_rows, k), self.knn_indices)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        let dist = Array2::from_shape_vec((self.n_rows, k), self.knn_distances)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+
+        let mut builder = UmapCore::builder_from_knn(idx, dist)
+            .n_components(self.n_components)
+            .min_dist(self.min_dist)
+            .spread(self.spread)
+            .learning_rate(self.learning_rate)
+            .negative_sample_rate(self.negative_sample_rate)
+            .repulsion_strength(self.repulsion_strength)
+            .local_connectivity(self.local_connectivity)
+            .set_op_mix_ratio(self.set_op_mix_ratio)
+            .init_method(self.init)
+            .optimizer(self.optimizer)
+            .gpu(self.gpu)
+            .verbose(self.verbose);
+        if let Some(n) = self.n_epochs {
+            builder = builder.n_epochs(n);
+        }
+        if let Some(seed) = self.random_state {
+            builder = builder.random_state(seed);
+        }
+        if let Some(cb) = &self.progress {
+            builder = builder.progress(js_to_progress_callback(cb.clone()));
+        }
+
+        let setup = builder
+            .setup_async()
+            .await
+            .map_err(|e| JsError::new(&e.to_string()))?;
+
+        let n_rows = setup.optimizer.embedding().nrows();
+        let n_components = setup.optimizer.embedding().ncols();
+        let n_neighbors_out = setup.knn_indices.ncols();
+
+        Ok(Umap {
+            optimizer: setup.optimizer,
+            graph: setup.graph,
+            knn_indices: setup.knn_indices.into_raw_vec_and_offset().0,
+            knn_distances: setup.knn_distances.into_raw_vec_and_offset().0,
+            n_neighbors_out,
+            n_rows,
+            n_components,
+            min_dist: self.min_dist,
+            spread: self.spread,
+            seed: self.random_state,
+            n_epochs: setup.n_epochs,
+            progress: self.progress,
+            verbose: self.verbose,
+        })
     }
 }
 

--- a/packages/umap/umap-wasm/tests/umap.test.js
+++ b/packages/umap/umap-wasm/tests/umap.test.js
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
-import { createUMAP } from "../index.js";
+import { createUMAP, createUMAPFromKNN } from "../index.js";
 import { initWasm, makeRandomData } from "./helpers.js";
 
 beforeAll(() => initWasm());
@@ -27,15 +27,20 @@ describe("createUMAP", () => {
     expect(umap.outputDim).toBe(OUTPUT_DIM);
   });
 
-  it("returns empty embedding before run()", async () => {
+  it("has a valid embedding immediately at epoch 0 (eager setup)", async () => {
     const data = makeRandomData(COUNT, INPUT_DIM);
     umap = await createUMAP(COUNT, INPUT_DIM, OUTPUT_DIM, data, {
       seed: 42,
       nEpochs: 10,
       initializeMethod: "random",
     });
-    expect(umap.embedding).toBeInstanceOf(Float32Array);
-    expect(umap.embedding.length).toBe(0);
+    expect(umap.epoch).toBe(0);
+    const emb = umap.embedding;
+    expect(emb).toBeInstanceOf(Float32Array);
+    expect(emb.length).toBe(COUNT * OUTPUT_DIM);
+    for (let i = 0; i < emb.length; i++) {
+      expect(Number.isFinite(emb[i])).toBe(true);
+    }
   });
 
   it("produces an embedding after run()", async () => {
@@ -54,18 +59,132 @@ describe("createUMAP", () => {
     }
   });
 
-  it("run() is idempotent", async () => {
+  it("run() advances to the horizon", async () => {
     const data = makeRandomData(COUNT, INPUT_DIM);
     umap = await createUMAP(COUNT, INPUT_DIM, OUTPUT_DIM, data, {
       seed: 42,
       nEpochs: 10,
       initializeMethod: "random",
     });
+    const before = new Float32Array(umap.embedding);
     await umap.run();
-    const emb1 = new Float32Array(umap.embedding);
+    expect(umap.epoch).toBe(10);
+    const after = umap.embedding;
+    // The layout should have moved from its initial position.
+    let moved = false;
+    for (let i = 0; i < after.length; i++) {
+      if (Math.abs(after[i] - before[i]) > 1e-6) {
+        moved = true;
+        break;
+      }
+    }
+    expect(moved).toBe(true);
+  });
+
+  it("step() advances the epoch and moves the embedding", async () => {
+    const data = makeRandomData(COUNT, INPUT_DIM);
+    umap = await createUMAP(COUNT, INPUT_DIM, OUTPUT_DIM, data, {
+      seed: 42,
+      nEpochs: 100,
+      initializeMethod: "random",
+    });
+    const before = new Float32Array(umap.embedding);
+    await umap.step(5);
+    expect(umap.epoch).toBe(5);
+    const after = umap.embedding;
+    expect(after.length).toBe(COUNT * OUTPUT_DIM);
+    let moved = false;
+    for (let i = 0; i < after.length; i++) {
+      expect(Number.isFinite(after[i])).toBe(true);
+      if (Math.abs(after[i] - before[i]) > 1e-6) moved = true;
+    }
+    expect(moved).toBe(true);
+  });
+
+  it("run() continues from the current epoch", async () => {
+    const data = makeRandomData(COUNT, INPUT_DIM);
+    umap = await createUMAP(COUNT, INPUT_DIM, OUTPUT_DIM, data, {
+      seed: 42,
+      nEpochs: 10,
+      initializeMethod: "random",
+    });
+    await umap.step(5);
+    expect(umap.epoch).toBe(5);
     await umap.run();
-    const emb2 = umap.embedding;
-    expect(emb1).toEqual(emb2);
+    expect(umap.epoch).toBe(10);
+  });
+
+  it("setParameters does not throw and keeps the layout finite", async () => {
+    const data = makeRandomData(COUNT, INPUT_DIM);
+    umap = await createUMAP(COUNT, INPUT_DIM, OUTPUT_DIM, data, {
+      seed: 42,
+      nEpochs: 50,
+      initializeMethod: "random",
+    });
+    umap.setParameters({
+      learningRate: 0.5,
+      repulsionStrength: 2.0,
+      negativeSampleRate: 7,
+      minDist: 0.2,
+      spread: 1.5,
+    });
+    await umap.step(10);
+    const emb = umap.embedding;
+    for (let i = 0; i < emb.length; i++) {
+      expect(Number.isFinite(emb[i])).toBe(true);
+    }
+  });
+
+  it("setOptimizer('momentum') does not throw and stays finite", async () => {
+    const data = makeRandomData(COUNT, INPUT_DIM);
+    umap = await createUMAP(COUNT, INPUT_DIM, OUTPUT_DIM, data, {
+      seed: 42,
+      nEpochs: 50,
+      initializeMethod: "random",
+    });
+    umap.setOptimizer("momentum");
+    await umap.step(20);
+    const emb = umap.embedding;
+    for (let i = 0; i < emb.length; i++) {
+      expect(Number.isFinite(emb[i])).toBe(true);
+    }
+  });
+
+  it("reset() restarts from epoch 0 (random and spectral)", async () => {
+    const data = makeRandomData(COUNT, INPUT_DIM);
+    umap = await createUMAP(COUNT, INPUT_DIM, OUTPUT_DIM, data, {
+      seed: 42,
+      nEpochs: 30,
+      initializeMethod: "random",
+    });
+    await umap.step(10);
+    expect(umap.epoch).toBe(10);
+
+    umap.reset("random");
+    expect(umap.epoch).toBe(0);
+    await umap.step(5);
+    expect(umap.epoch).toBe(5);
+    for (const v of umap.embedding) expect(Number.isFinite(v)).toBe(true);
+
+    umap.reset("spectral");
+    expect(umap.epoch).toBe(0);
+    await umap.step(5);
+    for (const v of umap.embedding) expect(Number.isFinite(v)).toBe(true);
+  });
+
+  it("accepts the momentum optimizer option", async () => {
+    const data = makeRandomData(COUNT, INPUT_DIM);
+    umap = await createUMAP(COUNT, INPUT_DIM, OUTPUT_DIM, data, {
+      seed: 42,
+      nEpochs: 30,
+      optimizer: "momentum",
+    });
+    await umap.run();
+    const emb = umap.embedding;
+    expect(emb.length).toBe(COUNT * OUTPUT_DIM);
+    for (let i = 0; i < emb.length; i++) {
+      expect(Number.isFinite(emb[i])).toBe(true);
+    }
   });
 
   it("destroy() clears the embedding", async () => {
@@ -75,7 +194,6 @@ describe("createUMAP", () => {
       nEpochs: 10,
       initializeMethod: "random",
     });
-    await umap.run();
     expect(umap.embedding.length).toBe(COUNT * OUTPUT_DIM);
     umap.destroy();
     expect(umap.embedding.length).toBe(0);
@@ -91,6 +209,68 @@ describe("createUMAP", () => {
     });
     await umap.run();
     umap.destroy();
+    umap.destroy();
+    umap = null;
+  });
+
+  it("destroy() during an in-flight step does not throw and frees cleanly", async () => {
+    const data = makeRandomData(COUNT, INPUT_DIM);
+    umap = await createUMAP(COUNT, INPUT_DIM, OUTPUT_DIM, data, {
+      seed: 42,
+      initializeMethod: "random",
+    });
+    // Start a step but don't await it — the wasm value is now borrowed, so a
+    // naive free() would throw "attempted to take ownership ... while borrowed".
+    const stepPromise = umap.step(20);
+    expect(() => umap.destroy()).not.toThrow();
+    // The free is queued after the in-flight step and runs once it settles.
+    await expect(stepPromise).resolves.toBeUndefined();
+    // The instance is now inert: getters are empty and further ops are no-ops.
+    expect(umap.embedding.length).toBe(0);
+    expect(umap.epoch).toBe(0);
+    await expect(umap.step(1)).resolves.toBeUndefined();
+    umap = null;
+  });
+
+  it("overlapping step() calls are serialized, not dropped (both run)", async () => {
+    const data = makeRandomData(COUNT, INPUT_DIM);
+    umap = await createUMAP(COUNT, INPUT_DIM, OUTPUT_DIM, data, {
+      seed: 42,
+      nEpochs: 100,
+      initializeMethod: "random",
+    });
+    // Fire two steps without awaiting the first: the second queues behind it and
+    // both run, so the epoch advances by the full 5 + 5 (not dropped, not just 5).
+    const p1 = umap.step(5);
+    const p2 = umap.step(5);
+    await Promise.all([p1, p2]);
+    expect(umap.epoch).toBe(10);
+    for (const v of umap.embedding) expect(Number.isFinite(v)).toBe(true);
+    umap.destroy();
+    umap = null;
+  });
+
+  it("getters serve the last settled snapshot during an in-flight step", async () => {
+    const data = makeRandomData(COUNT, INPUT_DIM);
+    umap = await createUMAP(COUNT, INPUT_DIM, OUTPUT_DIM, data, {
+      seed: 42,
+      initializeMethod: "random",
+    });
+    expect(umap.epoch).toBe(0);
+
+    // Start a step but don't await: while it is in flight the wasm value is
+    // borrowed, so the getters must serve snapshots rather than read wasm (which
+    // would throw "recursive use of an object detected" in GPU mode).
+    const stepPromise = umap.step(10);
+    expect(umap.epoch).toBe(0); // last settled value, not yet advanced
+    expect(umap.embedding.length).toBe(COUNT * OUTPUT_DIM);
+    // First-ever read of the (immutable) kNN graph mid-step must return the real
+    // graph, not an empty array — it is snapshotted at construction.
+    expect(umap.knnIndices.length).toBeGreaterThan(0);
+    expect(umap.knnDistances.length).toBe(umap.knnIndices.length);
+
+    await stepPromise;
+    expect(umap.epoch).toBe(10); // refreshed once the step settled
     umap.destroy();
     umap = null;
   });
@@ -151,6 +331,7 @@ describe("createUMAP", () => {
     umap = await createUMAP(COUNT, INPUT_DIM, OUTPUT_DIM, data, {
       metric: "euclidean",
       initializeMethod: "random",
+      optimizer: "sgd",
       localConnectivity: 1.0,
       mixRatio: 1.0,
       spread: 1.0,
@@ -166,20 +347,7 @@ describe("createUMAP", () => {
     expect(umap.embedding.length).toBe(COUNT * OUTPUT_DIM);
   });
 
-  it("returns empty knnIndices and knnDistances before run()", async () => {
-    const data = makeRandomData(COUNT, INPUT_DIM);
-    umap = await createUMAP(COUNT, INPUT_DIM, OUTPUT_DIM, data, {
-      seed: 42,
-      nEpochs: 10,
-      initializeMethod: "random",
-    });
-    expect(umap.knnIndices).toBeInstanceOf(Int32Array);
-    expect(umap.knnIndices.length).toBe(0);
-    expect(umap.knnDistances).toBeInstanceOf(Float32Array);
-    expect(umap.knnDistances.length).toBe(0);
-  });
-
-  it("produces knnIndices and knnDistances after run()", async () => {
+  it("has valid knnIndices and knnDistances immediately (eager setup)", async () => {
     const N_NEIGHBORS = 10;
     const data = makeRandomData(COUNT, INPUT_DIM);
     umap = await createUMAP(COUNT, INPUT_DIM, OUTPUT_DIM, data, {
@@ -188,7 +356,6 @@ describe("createUMAP", () => {
       nNeighbors: N_NEIGHBORS,
       initializeMethod: "random",
     });
-    await umap.run();
     expect(umap.knnIndices).toBeInstanceOf(Int32Array);
     expect(umap.knnIndices.length).toBe(COUNT * N_NEIGHBORS);
     expect(umap.knnDistances).toBeInstanceOf(Float32Array);
@@ -201,36 +368,139 @@ describe("createUMAP", () => {
     }
   });
 
-  it("throws on unknown metric", async () => {
+  it("throws on unknown metric (at create, eager setup)", async () => {
     const data = makeRandomData(COUNT, INPUT_DIM);
-    umap = await createUMAP(COUNT, INPUT_DIM, OUTPUT_DIM, data, {
-      metric: "nonexistent",
-      nEpochs: 10,
-      initializeMethod: "random",
-      seed: 42,
-    });
-    await expect(umap.run()).rejects.toThrow(/unknown metric/i);
+    await expect(
+      createUMAP(COUNT, INPUT_DIM, OUTPUT_DIM, data, {
+        metric: "nonexistent",
+        nEpochs: 10,
+        initializeMethod: "random",
+        seed: 42,
+      }),
+    ).rejects.toThrow(/unknown metric/i);
   });
 
-  it("throws when nNeighbors >= count", async () => {
-    const data = makeRandomData(COUNT, INPUT_DIM);
-    umap = await createUMAP(COUNT, INPUT_DIM, OUTPUT_DIM, data, {
-      nNeighbors: COUNT,
-      nEpochs: 10,
-      initializeMethod: "random",
-      seed: 42,
-    });
-    await expect(umap.run()).rejects.toThrow(/n_neighbors/i);
-  });
-
-  it("throws on data length mismatch", async () => {
+  it("throws on data length mismatch (at create)", async () => {
     const data = makeRandomData(COUNT, INPUT_DIM);
     // Pass wrong count so data.length != count * inputDim
-    umap = await createUMAP(COUNT + 1, INPUT_DIM, OUTPUT_DIM, data, {
+    await expect(
+      createUMAP(COUNT + 1, INPUT_DIM, OUTPUT_DIM, data, {
+        nEpochs: 10,
+        initializeMethod: "random",
+        seed: 42,
+      }),
+    ).rejects.toThrow(/length/i);
+  });
+});
+
+describe("createUMAPFromKNN", () => {
+  const COUNT = 200;
+  const INPUT_DIM = 10;
+  const OUTPUT_DIM = 2;
+  const K = 10;
+
+  let umap;
+
+  afterEach(() => {
+    umap?.destroy();
+    umap = null;
+  });
+
+  // A valid canonical kNN graph (self in column 0) produced by a normal UMAP setup.
+  async function makeKnn(seed = 42) {
+    const data = makeRandomData(COUNT, INPUT_DIM);
+    const ref = await createUMAP(COUNT, INPUT_DIM, OUTPUT_DIM, data, {
+      seed,
+      nEpochs: 1,
+      nNeighbors: K,
+      initializeMethod: "random",
+    });
+    const knnIndices = new Int32Array(ref.knnIndices);
+    const knnDistances = new Float32Array(ref.knnDistances);
+    ref.destroy();
+    return { knnIndices, knnDistances };
+  }
+
+  it("builds from a precomputed kNN graph (no data needed)", async () => {
+    const { knnIndices, knnDistances } = await makeKnn();
+    umap = await createUMAPFromKNN(COUNT, OUTPUT_DIM, knnIndices, knnDistances, {
+      seed: 42,
       nEpochs: 10,
       initializeMethod: "random",
-      seed: 42,
     });
-    await expect(umap.run()).rejects.toThrow(/length/i);
+    expect(umap.outputDim).toBe(OUTPUT_DIM);
+    expect(umap.epoch).toBe(0);
+
+    const emb = umap.embedding;
+    expect(emb.length).toBe(COUNT * OUTPUT_DIM);
+    for (let i = 0; i < emb.length; i++) {
+      expect(Number.isFinite(emb[i])).toBe(true);
+    }
+
+    // The echoed graph is row-major and consistent across indices/distances.
+    expect(umap.knnIndices.length).toBe(umap.knnDistances.length);
+    expect(umap.knnIndices.length % COUNT).toBe(0);
+    expect(umap.knnIndices.length).toBeGreaterThan(0);
+
+    await umap.run();
+    expect(umap.epoch).toBe(10);
+    for (const v of umap.embedding) expect(Number.isFinite(v)).toBe(true);
+  });
+
+  it("is deterministic for a fixed seed", async () => {
+    const { knnIndices, knnDistances } = await makeKnn();
+    const opts = { seed: 7, nEpochs: 10, initializeMethod: "random" };
+
+    const u1 = await createUMAPFromKNN(COUNT, OUTPUT_DIM, knnIndices, knnDistances, opts);
+    await u1.run();
+    const e1 = new Float32Array(u1.embedding);
+    u1.destroy();
+
+    const u2 = await createUMAPFromKNN(COUNT, OUTPUT_DIM, knnIndices, knnDistances, opts);
+    await u2.run();
+    const e2 = new Float32Array(u2.embedding);
+    u2.destroy();
+
+    expect(e1).toEqual(e2);
+  });
+
+  it("accepts a self-excluded graph and widens to include self", async () => {
+    // K real neighbors per row, none of which is the point itself.
+    const N = 50;
+    const k = 5;
+    const indices = new Int32Array(N * k);
+    const distances = new Float32Array(N * k);
+    for (let i = 0; i < N; i++) {
+      for (let off = 1; off <= k; off++) {
+        const c = i * k + (off - 1);
+        indices[c] = (i + off) % N;
+        distances[c] = off; // already ascending
+      }
+    }
+    umap = await createUMAPFromKNN(N, OUTPUT_DIM, indices, distances, {
+      seed: 1,
+      nEpochs: 10,
+      initializeMethod: "random",
+    });
+    expect(umap.embedding.length).toBe(N * OUTPUT_DIM);
+    for (const v of umap.embedding) expect(Number.isFinite(v)).toBe(true);
+    // Self prepended -> width grows from k to k + 1.
+    expect(umap.knnIndices.length).toBe(N * (k + 1));
+  });
+
+  it("throws on mismatched indices/distances length", async () => {
+    const indices = new Int32Array(20 * 5);
+    const distances = new Float32Array(20 * 6);
+    await expect(createUMAPFromKNN(20, OUTPUT_DIM, indices, distances, { nEpochs: 5 })).rejects.toThrow(
+      /equal length/i,
+    );
+  });
+
+  it("throws when length is not divisible by count", async () => {
+    const indices = new Int32Array(21);
+    const distances = new Float32Array(21);
+    await expect(createUMAPFromKNN(20, OUTPUT_DIM, indices, distances, { nEpochs: 5 })).rejects.toThrow(
+      /divisible|nRows/i,
+    );
   });
 });

--- a/packages/umap/umap/src/gpu_optimize.rs
+++ b/packages/umap/umap/src/gpu_optimize.rs
@@ -1,56 +1,79 @@
-/// GPU-accelerated UMAP SGD optimization using wgpu compute shaders.
+/// Resident GPU context for UMAP velocity-SGD optimization (wgpu compute).
 ///
-/// Uses a two-pass approach per sub-batch:
-///   1. accumulate_grads: computes per-edge gradients and atomicAdds them
-///      to a fixed-point i32 buffer (no lost updates from GPU write conflicts).
-///   2. apply_grads: converts accumulated gradients from fixed-point, applies
-///      them to the embedding with the current learning rate, and clears the
-///      accumulator.
+/// All buffers (embedding, edge list, per-edge schedule counters, gradient
+/// accumulator, velocity) are uploaded once and live for the whole run. Each
+/// `run_epoch` dispatches the self-scheduling `accumulate_grads` shader (in
+/// sub-batches for SGD, a single round for Momentum) followed by `apply_grads`.
+/// The CPU mirror is refreshed by `download_embedding` at the end of a step.
 ///
-/// Edges are split into sub-batches dispatched sequentially to approximate
-/// CPU Hogwild behavior where later edges see partially-updated positions.
-use ndarray::Array2;
-use nndescent::Logger;
+/// Two-pass-per-sub-batch design: `accumulate_grads` atomicAdds per-edge
+/// gradients into a fixed-point i32 buffer (no lost updates from write
+/// conflicts); `apply_grads` reads/clears the accumulator and applies the step.
+use crate::optimize::{LiveParams, Optimizer};
 
-/// Uniform parameters passed to the optimize compute shader.
+/// Uniform parameters passed to the optimize compute shaders. std140-compatible:
+/// 16 four-byte scalars = 64 bytes, every member naturally aligned.
 #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 struct OptimizeParams {
     n_vertices: u32,
     dim: u32,
     n_edges: u32,
-    _pad0: u32,
+    epoch: u32,
     a: f32,
     b: f32,
     gamma: f32,
     alpha: f32,
     grad_clamp: f32,
+    negative_sample_rate: f32,
+    base_seed: u32,
     /// Base element offset for chunked apply_grads dispatch.
     apply_offset: u32,
-    _pad2: f32,
-    _pad3: f32,
+    /// Sub-batch edge range [edge_offset, edge_end) for accumulate_grads.
+    edge_offset: u32,
+    edge_end: u32,
+    /// 0 = Sgd, 1 = Momentum.
+    optimizer: u32,
+    beta: f32,
 }
 
-/// Holds wgpu state for the GPU optimization pipeline.
-struct OptimizeGpuContext {
+/// Holds resident wgpu state for the GPU optimization pipeline.
+pub struct OptimizeGpuContext {
     device: wgpu::Device,
     queue: wgpu::Queue,
     accumulate_pipeline: wgpu::ComputePipeline,
     apply_pipeline: wgpu::ComputePipeline,
-    bind_group_layout: wgpu::BindGroupLayout,
+    rebase_pipeline: wgpu::ComputePipeline,
+    accumulate_bind_group: wgpu::BindGroup,
+    apply_bind_group: wgpu::BindGroup,
+    rebase_bind_group: wgpu::BindGroup,
     embedding_buffer: wgpu::Buffer,
-    edges_buffer: wgpu::Buffer,
-    params_buffer: wgpu::Buffer,
+    // head/tail/eps are uploaded once and only referenced by the accumulate bind
+    // group; retained here so the buffers outlive that bind group.
+    #[allow(dead_code)]
+    head_buffer: wgpu::Buffer,
+    #[allow(dead_code)]
+    tail_buffer: wgpu::Buffer,
+    #[allow(dead_code)]
+    eps_buffer: wgpu::Buffer,
+    eons_buffer: wgpu::Buffer,
+    eonns_buffer: wgpu::Buffer,
     grad_accum_buffer: wgpu::Buffer,
+    velocity_buffer: wgpu::Buffer,
+    params_buffer: wgpu::Buffer,
     embedding_staging: wgpu::Buffer,
+    /// Initial epochs_per_sample (CPU copy), used to reset the schedule counters.
+    eps: Vec<f32>,
     n_vertices: u32,
     dim: u32,
-    max_edges_per_dispatch: usize,
+    n_edges: usize,
+    n_neighbors: usize,
+    grad_clamp: f32,
+    base_seed: u32,
     max_workgroups_per_dim: u32,
 }
 
 /// Async helper: map a buffer for reading and wait for it to be available.
-/// Duplicated from nndescent::gpu (internal to that crate).
 async fn map_buffer_read(
     device: &wgpu::Device,
     buffer: &wgpu::Buffer,
@@ -95,8 +118,8 @@ async fn map_buffer_read(
     }
 }
 
-/// Helper to create a storage buffer bind group layout entry.
-fn bgl_entry(binding: u32, read_only: bool) -> wgpu::BindGroupLayoutEntry {
+/// Storage-buffer bind group layout entry.
+fn storage_entry(binding: u32, read_only: bool) -> wgpu::BindGroupLayoutEntry {
     wgpu::BindGroupLayoutEntry {
         binding,
         visibility: wgpu::ShaderStages::COMPUTE,
@@ -109,12 +132,50 @@ fn bgl_entry(binding: u32, read_only: bool) -> wgpu::BindGroupLayoutEntry {
     }
 }
 
+/// Uniform-buffer bind group layout entry.
+fn uniform_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::COMPUTE,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Uniform,
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    }
+}
+
+fn storage_buffer(device: &wgpu::Device, label: &str, size: u64) -> wgpu::Buffer {
+    device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some(label),
+        size: size.max(4),
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    })
+}
+
 impl OptimizeGpuContext {
-    /// Create a new GPU context for UMAP optimization.
-    ///
-    /// Uploads the initial embedding and compiles the optimization shaders.
-    /// Returns `None` if no suitable GPU adapter is available.
-    async fn new(embedding: &[f32], n_vertices: u32, dim: u32) -> Option<Self> {
+    /// Create a resident GPU context. Returns `None` if no suitable adapter is
+    /// available, the buffers exceed device limits, or there are no edges (the
+    /// caller then uses the CPU path, which is a no-op for an empty edge list).
+    #[allow(clippy::too_many_arguments)]
+    pub async fn new(
+        embedding: &[f32],
+        head: &[u32],
+        tail: &[u32],
+        epochs_per_sample: &[f32],
+        n_vertices: u32,
+        dim: u32,
+        n_neighbors: usize,
+        negative_sample_rate: f32,
+        rng_state: [i64; 3],
+    ) -> Option<Self> {
+        let n_edges = head.len();
+        if n_edges == 0 || n_vertices == 0 || dim == 0 {
+            return None;
+        }
+
         let backends = if cfg!(target_arch = "wasm32") {
             wgpu::Backends::BROWSER_WEBGPU
         } else {
@@ -149,23 +210,20 @@ impl OptimizeGpuContext {
             .ok()?;
 
         let limits = device.limits();
-        let max_binding_size = limits.max_storage_buffer_binding_size as u64;
-        let max_buffer_size = limits.max_buffer_size;
-        let buffer_limit = max_binding_size.min(max_buffer_size);
+        let buffer_limit =
+            (limits.max_storage_buffer_binding_size as u64).min(limits.max_buffer_size);
 
-        // Each edge is 4 × u32 = 16 bytes
-        let max_edges_from_buffer = buffer_limit / 16;
-        let max_edges_from_dispatch = 65535u64 * 256;
-        let max_edges_per_dispatch = max_edges_from_buffer.min(max_edges_from_dispatch) as usize;
-
-        // Validate that embedding and grad_accum fit within device limits
         let embedding_bytes = (embedding.len() * 4) as u64;
         let grad_accum_bytes = (n_vertices as u64) * (dim as u64) * 4;
-        if embedding_bytes > buffer_limit || grad_accum_bytes > buffer_limit {
-            return None; // Embedding too large for this GPU
+        let edge_bytes = (n_edges as u64) * 4;
+        if embedding_bytes > buffer_limit
+            || grad_accum_bytes > buffer_limit
+            || edge_bytes > buffer_limit
+        {
+            return None;
         }
 
-        // Upload embedding
+        // --- Buffers ---
         let embedding_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("embedding"),
             size: embedding_bytes,
@@ -176,15 +234,22 @@ impl OptimizeGpuContext {
         });
         queue.write_buffer(&embedding_buffer, 0, bytemuck::cast_slice(embedding));
 
-        // Pre-allocate edges buffer (sized for max chunk)
-        let edges_buffer = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("edges"),
-            size: (max_edges_per_dispatch as u64) * 16,
-            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
+        let head_buffer = storage_buffer(&device, "head", edge_bytes);
+        queue.write_buffer(&head_buffer, 0, bytemuck::cast_slice(head));
+        let tail_buffer = storage_buffer(&device, "tail", edge_bytes);
+        queue.write_buffer(&tail_buffer, 0, bytemuck::cast_slice(tail));
+        let eps_buffer = storage_buffer(&device, "eps", edge_bytes);
+        queue.write_buffer(&eps_buffer, 0, bytemuck::cast_slice(epochs_per_sample));
 
-        // Params buffer
+        let eons_buffer = storage_buffer(&device, "eons", edge_bytes);
+        let eonns_buffer = storage_buffer(&device, "eonns", edge_bytes);
+
+        let grad_accum_buffer = storage_buffer(&device, "grad_accum", grad_accum_bytes);
+        queue.write_buffer(&grad_accum_buffer, 0, &vec![0u8; grad_accum_bytes as usize]);
+
+        let velocity_buffer = storage_buffer(&device, "velocity", grad_accum_bytes);
+        queue.write_buffer(&velocity_buffer, 0, &vec![0u8; grad_accum_bytes as usize]);
+
         let params_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("optimize_params"),
             size: std::mem::size_of::<OptimizeParams>() as u64,
@@ -192,17 +257,6 @@ impl OptimizeGpuContext {
             mapped_at_creation: false,
         });
 
-        // Gradient accumulation buffer (atomic<i32>, same layout as embedding)
-        let grad_accum_buffer = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("grad_accum"),
-            size: grad_accum_bytes,
-            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-        // Zero-initialize
-        queue.write_buffer(&grad_accum_buffer, 0, &vec![0u8; grad_accum_bytes as usize]);
-
-        // Staging buffer for final readback
         let embedding_staging = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("embedding_staging"),
             size: embedding_bytes,
@@ -210,76 +264,67 @@ impl OptimizeGpuContext {
             mapped_at_creation: false,
         });
 
-        // Compile shader (contains both entry points)
-        let shader_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        // --- Shader + pipelines (separate bind group layouts to stay within the
+        //     8-storage-buffers-per-stage limit; accumulate peaks at 7). ---
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("optimize_shader"),
             source: wgpu::ShaderSource::Wgsl(include_str!("shaders/optimize.wgsl").into()),
         });
 
-        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("optimize_bgl"),
+        let accumulate_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("accumulate_bgl"),
             entries: &[
-                bgl_entry(0, false), // embedding (read_write)
-                bgl_entry(1, true),  // edges (read)
-                wgpu::BindGroupLayoutEntry {
-                    binding: 2,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                bgl_entry(3, false), // grad_accum (read_write)
+                storage_entry(0, false), // embedding rw
+                storage_entry(1, true),  // head ro
+                storage_entry(2, true),  // tail ro
+                storage_entry(3, true),  // eps ro
+                storage_entry(4, false), // eons rw
+                storage_entry(5, false), // eonns rw
+                storage_entry(6, false), // grad_accum rw
+                uniform_entry(8),        // params
+            ],
+        });
+        let apply_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("apply_bgl"),
+            entries: &[
+                storage_entry(0, false), // embedding rw
+                storage_entry(6, false), // grad_accum rw
+                storage_entry(7, false), // velocity rw
+                uniform_entry(8),        // params
+            ],
+        });
+        let rebase_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("rebase_bgl"),
+            entries: &[
+                storage_entry(4, false), // eons rw
+                storage_entry(5, false), // eonns rw
+                uniform_entry(8),        // params
             ],
         });
 
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("optimize_pipeline_layout"),
-            bind_group_layouts: &[&bind_group_layout],
-            push_constant_ranges: &[],
-        });
-
-        let accumulate_pipeline =
+        let make_pipeline = |bgl: &wgpu::BindGroupLayout, entry: &str, label: &str| {
+            let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some(label),
+                bind_group_layouts: &[bgl],
+                push_constant_ranges: &[],
+            });
             device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-                label: Some("accumulate_pipeline"),
-                layout: Some(&pipeline_layout),
-                module: &shader_module,
-                entry_point: Some("accumulate_grads"),
+                label: Some(label),
+                layout: Some(&layout),
+                module: &shader,
+                entry_point: Some(entry),
                 compilation_options: Default::default(),
                 cache: None,
-            });
-
-        let apply_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-            label: Some("apply_pipeline"),
-            layout: Some(&pipeline_layout),
-            module: &shader_module,
-            entry_point: Some("apply_grads"),
-            compilation_options: Default::default(),
-            cache: None,
-        });
-
-        // Warm up with a tiny dispatch to trigger shader compilation
-        let warmup_params = OptimizeParams {
-            n_vertices,
-            dim,
-            n_edges: 0,
-            _pad0: 0,
-            a: 1.0,
-            b: 1.0,
-            gamma: 1.0,
-            alpha: 0.0,
-            grad_clamp: 20.0,
-            apply_offset: 0,
-            _pad2: 0.0,
-            _pad3: 0.0,
+            })
         };
-        queue.write_buffer(&params_buffer, 0, bytemuck::cast_slice(&[warmup_params]));
+        let accumulate_pipeline = make_pipeline(&accumulate_bgl, "accumulate_grads", "accumulate");
+        let apply_pipeline = make_pipeline(&apply_bgl, "apply_grads", "apply");
+        let rebase_pipeline = make_pipeline(&rebase_bgl, "rebase_schedule", "rebase");
 
-        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("warmup_bg"),
-            layout: &bind_group_layout,
+        // --- Bind groups (static: buffers don't change identity). ---
+        let accumulate_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("accumulate_bg"),
+            layout: &accumulate_bgl,
             entries: &[
                 wgpu::BindGroupEntry {
                     binding: 0,
@@ -287,215 +332,324 @@ impl OptimizeGpuContext {
                 },
                 wgpu::BindGroupEntry {
                     binding: 1,
-                    resource: edges_buffer.as_entire_binding(),
+                    resource: head_buffer.as_entire_binding(),
                 },
                 wgpu::BindGroupEntry {
                     binding: 2,
-                    resource: params_buffer.as_entire_binding(),
+                    resource: tail_buffer.as_entire_binding(),
                 },
                 wgpu::BindGroupEntry {
                     binding: 3,
+                    resource: eps_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: eons_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 5,
+                    resource: eonns_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 6,
                     resource: grad_accum_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 8,
+                    resource: params_buffer.as_entire_binding(),
+                },
+            ],
+        });
+        let apply_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("apply_bg"),
+            layout: &apply_bgl,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: embedding_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 6,
+                    resource: grad_accum_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 7,
+                    resource: velocity_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 8,
+                    resource: params_buffer.as_entire_binding(),
+                },
+            ],
+        });
+        let rebase_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("rebase_bg"),
+            layout: &rebase_bgl,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: eons_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 5,
+                    resource: eonns_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 8,
+                    resource: params_buffer.as_entire_binding(),
                 },
             ],
         });
 
-        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("warmup_encoder"),
-        });
-        {
-            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
-                label: Some("warmup_pass"),
-                timestamp_writes: None,
-            });
-            pass.set_pipeline(&accumulate_pipeline);
-            pass.set_bind_group(0, &bind_group, &[]);
-            pass.dispatch_workgroups(1, 1, 1);
-        }
-        {
-            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
-                label: Some("warmup_apply_pass"),
-                timestamp_writes: None,
-            });
-            pass.set_pipeline(&apply_pipeline);
-            pass.set_bind_group(0, &bind_group, &[]);
-            pass.dispatch_workgroups(1, 1, 1);
-        }
-        queue.submit(std::iter::once(encoder.finish()));
+        let edge_clamp = 4.0f32;
+        let grad_clamp = edge_clamp * (7.0 * n_neighbors as f32).sqrt();
+        let base_seed = (rng_state[0] as u32)
+            .wrapping_add(rng_state[1] as u32)
+            .wrapping_add(rng_state[2] as u32);
 
-        Some(OptimizeGpuContext {
+        let ctx = OptimizeGpuContext {
             device,
             queue,
             accumulate_pipeline,
             apply_pipeline,
-            bind_group_layout,
+            rebase_pipeline,
+            accumulate_bind_group,
+            apply_bind_group,
+            rebase_bind_group,
             embedding_buffer,
-            edges_buffer,
-            params_buffer,
+            head_buffer,
+            tail_buffer,
+            eps_buffer,
+            eons_buffer,
+            eonns_buffer,
             grad_accum_buffer,
+            velocity_buffer,
+            params_buffer,
             embedding_staging,
+            eps: epochs_per_sample.to_vec(),
             n_vertices,
             dim,
-            max_edges_per_dispatch,
+            n_edges,
+            n_neighbors,
+            grad_clamp,
+            base_seed,
             max_workgroups_per_dim: limits.max_compute_workgroups_per_dimension,
-        })
+        };
+
+        // Initialize the schedule counters.
+        ctx.reset_schedule(negative_sample_rate);
+
+        Some(ctx)
     }
 
-    /// Run one epoch of SGD on the GPU.
-    ///
-    /// `packed_edges` is a flat [head, tail, n_neg, rng_seed, ...] array (4 u32 per edge).
-    /// All edges accumulate gradients atomically in one pass, then a second pass
-    /// applies the accumulated gradients to the embedding.
-    fn run_epoch(
+    /// Reset the per-edge schedule counters (eons = eps, eonns = eps/rate) and
+    /// clear the gradient accumulator.
+    pub fn reset_schedule(&self, negative_sample_rate: f32) {
+        self.queue
+            .write_buffer(&self.eons_buffer, 0, bytemuck::cast_slice(&self.eps));
+        let eonns: Vec<f32> = if negative_sample_rate > 0.0 {
+            self.eps.iter().map(|&e| e / negative_sample_rate).collect()
+        } else {
+            self.eps.clone()
+        };
+        self.queue
+            .write_buffer(&self.eonns_buffer, 0, bytemuck::cast_slice(&eonns));
+        self.zero_grad_accum();
+    }
+
+    /// Re-seed only the negative-sample counters (`eonns`) for a new rate,
+    /// relative to `from_epoch` (the current `gpu_epoch`). Unlike
+    /// [`reset_schedule`](Self::reset_schedule) this leaves the positive-sample
+    /// counters and the gradient accumulator untouched, so it is safe to call
+    /// mid-run when the live `negative_sample_rate` changes.
+    pub fn reseed_negative_schedule(&self, negative_sample_rate: f32, from_epoch: u32) {
+        let from = from_epoch as f32;
+        let eonns: Vec<f32> = if negative_sample_rate > 0.0 {
+            self.eps
+                .iter()
+                .map(|&e| from + e / negative_sample_rate)
+                .collect()
+        } else {
+            // Parked: the shader's `rate > 0` guard skips reading these.
+            vec![f32::INFINITY; self.eps.len()]
+        };
+        self.queue
+            .write_buffer(&self.eonns_buffer, 0, bytemuck::cast_slice(&eonns));
+    }
+
+    /// Re-upload the embedding (used by `reinit_embedding`).
+    pub fn reupload_embedding(&self, embedding: &[f32]) {
+        self.queue
+            .write_buffer(&self.embedding_buffer, 0, bytemuck::cast_slice(embedding));
+    }
+
+    /// Zero the velocity buffer (on optimizer switch / reinit).
+    pub fn zero_velocity(&self) {
+        let bytes = (self.n_vertices as usize) * (self.dim as usize) * 4;
+        self.queue
+            .write_buffer(&self.velocity_buffer, 0, &vec![0u8; bytes]);
+    }
+
+    fn zero_grad_accum(&self) {
+        let bytes = (self.n_vertices as usize) * (self.dim as usize) * 4;
+        self.queue
+            .write_buffer(&self.grad_accum_buffer, 0, &vec![0u8; bytes]);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn params_for(
         &self,
-        packed_edges: &[u32],
-        n_edges: usize,
-        alpha: f32,
-        a: f32,
-        b: f32,
-        gamma: f32,
-        grad_clamp: f32,
+        epoch: u32,
+        params: LiveParams,
+        beta: f32,
+        opt_flag: u32,
+        apply_offset: u32,
+        edge_offset: u32,
+        edge_end: u32,
+    ) -> OptimizeParams {
+        OptimizeParams {
+            n_vertices: self.n_vertices,
+            dim: self.dim,
+            n_edges: self.n_edges as u32,
+            epoch,
+            a: params.a,
+            b: params.b,
+            gamma: params.gamma,
+            alpha: params.alpha,
+            grad_clamp: self.grad_clamp,
+            negative_sample_rate: params.negative_sample_rate,
+            base_seed: self.base_seed,
+            apply_offset,
+            edge_offset,
+            edge_end,
+            optimizer: opt_flag,
+            beta,
+        }
+    }
+
+    fn dispatch(
+        &self,
+        pipeline: &wgpu::ComputePipeline,
+        bind_group: &wgpu::BindGroup,
+        workgroups: u32,
+        label: &str,
     ) {
-        if n_edges == 0 {
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some(label) });
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some(label),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(pipeline);
+            pass.set_bind_group(0, bind_group, &[]);
+            pass.dispatch_workgroups(workgroups, 1, 1);
+        }
+        self.queue.submit(std::iter::once(encoder.finish()));
+    }
+
+    /// Run one epoch on the GPU at the given (already-decayed) parameters.
+    ///
+    /// SGD splits the epoch into `n_sub` accumulate→apply rounds so later
+    /// sub-batches see partially-updated positions (emulating CPU Hogwild and
+    /// preventing full-batch overshoot). Momentum runs a single coherent round.
+    pub fn run_epoch(&self, epoch: u32, params: LiveParams, beta: f32, optimizer: Optimizer) {
+        if self.n_edges == 0 {
             return;
         }
 
-        // Accumulate gradients (chunk if edges exceed buffer capacity)
-        if n_edges > self.max_edges_per_dispatch {
-            for chunk_start in (0..n_edges).step_by(self.max_edges_per_dispatch) {
-                let chunk_end = (chunk_start + self.max_edges_per_dispatch).min(n_edges);
-                let chunk_n = chunk_end - chunk_start;
-                let chunk_data = &packed_edges[chunk_start * 4..chunk_end * 4];
-                self.dispatch_accumulate(chunk_data, chunk_n, alpha, a, b, gamma, grad_clamp);
+        let (n_sub, opt_flag) = match optimizer {
+            Optimizer::Sgd => {
+                let per_vertex = (2.0 + params.negative_sample_rate) * self.n_neighbors as f32;
+                ((per_vertex.sqrt().ceil() as usize).clamp(4, 32), 0u32)
             }
-        } else {
-            self.dispatch_accumulate(packed_edges, n_edges, alpha, a, b, gamma, grad_clamp);
-        }
-
-        // Apply accumulated gradients and clear accumulator
-        // Chunk dispatch to respect max_compute_workgroups_per_dimension
-        let total_elements = self.n_vertices * self.dim;
-        let max_invocations = self.max_workgroups_per_dim * 256;
-        let mut base = 0u32;
-        while base < total_elements {
-            let remaining = total_elements - base;
-            let chunk = remaining.min(max_invocations);
-            let workgroups = (chunk + 255) / 256;
-            self.dispatch_apply(workgroups, base);
-            base += chunk;
-        }
-    }
-
-    /// Upload edges and dispatch the accumulate_grads shader.
-    fn dispatch_accumulate(
-        &self,
-        packed_edges: &[u32],
-        n_edges: usize,
-        alpha: f32,
-        a: f32,
-        b: f32,
-        gamma: f32,
-        grad_clamp: f32,
-    ) {
-        let params = OptimizeParams {
-            n_vertices: self.n_vertices,
-            dim: self.dim,
-            n_edges: n_edges as u32,
-            _pad0: 0,
-            a,
-            b,
-            gamma,
-            alpha,
-            grad_clamp,
-            apply_offset: 0,
-            _pad2: 0.0,
-            _pad3: 0.0,
+            Optimizer::Momentum => (1, 1u32),
         };
-        self.queue
-            .write_buffer(&self.params_buffer, 0, bytemuck::cast_slice(&[params]));
-        self.queue
-            .write_buffer(&self.edges_buffer, 0, bytemuck::cast_slice(packed_edges));
 
-        let bind_group = self.create_bind_group("accumulate_bg");
+        let max_invocations = self.max_workgroups_per_dim * 256;
+        let sub_size = self.n_edges.div_ceil(n_sub);
 
-        let workgroup_count = ((n_edges as u32) + 255) / 256;
-        let mut encoder = self
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("accumulate_encoder"),
-            });
-        {
-            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
-                label: Some("accumulate_pass"),
-                timestamp_writes: None,
-            });
-            pass.set_pipeline(&self.accumulate_pipeline);
-            pass.set_bind_group(0, &bind_group, &[]);
-            pass.dispatch_workgroups(workgroup_count, 1, 1);
+        for sub_start in (0..self.n_edges).step_by(sub_size) {
+            let sub_end = (sub_start + sub_size).min(self.n_edges);
+
+            // Accumulate [sub_start, sub_end), chunked to respect dispatch limits.
+            let mut off = sub_start as u32;
+            let end = sub_end as u32;
+            while off < end {
+                let count = (end - off).min(max_invocations);
+                let p = self.params_for(epoch, params, beta, opt_flag, 0, off, off + count);
+                self.queue
+                    .write_buffer(&self.params_buffer, 0, bytemuck::cast_slice(&[p]));
+                self.dispatch(
+                    &self.accumulate_pipeline,
+                    &self.accumulate_bind_group,
+                    count.div_ceil(256),
+                    "accumulate",
+                );
+                off += count;
+            }
+
+            // Apply all elements (chunked) and clear the accumulator.
+            let total = self.n_vertices * self.dim;
+            let mut base = 0u32;
+            while base < total {
+                let chunk = (total - base).min(max_invocations);
+                let p = self.params_for(epoch, params, beta, opt_flag, base, 0, 0);
+                self.queue
+                    .write_buffer(&self.params_buffer, 0, bytemuck::cast_slice(&[p]));
+                self.dispatch(
+                    &self.apply_pipeline,
+                    &self.apply_bind_group,
+                    chunk.div_ceil(256),
+                    "apply",
+                );
+                base += chunk;
+            }
         }
-        self.queue.submit(std::iter::once(encoder.finish()));
     }
 
-    /// Dispatch the apply_grads shader to update the embedding and clear grad_accum.
-    ///
-    /// `apply_offset` is the base element index for this chunk of the apply pass.
-    fn dispatch_apply(&self, apply_workgroups: u32, apply_offset: u32) {
-        // Update apply_offset in params. The other fields (alpha, n_vertices, dim, etc.)
-        // were already uploaded in dispatch_accumulate and don't change between chunks.
-        // We re-upload the full params to set apply_offset.
-        self.queue.write_buffer(
-            &self.params_buffer,
-            std::mem::offset_of!(OptimizeParams, apply_offset) as u64,
-            bytemuck::cast_slice(&[apply_offset]),
-        );
-
-        let bind_group = self.create_bind_group("apply_bg");
-
-        let mut encoder = self
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("apply_encoder"),
-            });
-        {
-            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
-                label: Some("apply_pass"),
-                timestamp_writes: None,
-            });
-            pass.set_pipeline(&self.apply_pipeline);
-            pass.set_bind_group(0, &bind_group, &[]);
-            pass.dispatch_workgroups(apply_workgroups, 1, 1);
+    /// Subtract `base` from both schedule-counter buffers (keeps the f32 epoch
+    /// coordinate precise over indefinitely long runs).
+    pub fn rebase(&self, base: u32) {
+        if self.n_edges == 0 {
+            return;
         }
-        self.queue.submit(std::iter::once(encoder.finish()));
+        let max_invocations = self.max_workgroups_per_dim * 256;
+        let total = self.n_edges as u32;
+        let mut off = 0u32;
+        while off < total {
+            let count = (total - off).min(max_invocations);
+            let mut p = self.params_for(
+                base,
+                LiveParams {
+                    alpha: 0.0,
+                    gamma: 1.0,
+                    negative_sample_rate: 0.0,
+                    a: 1.0,
+                    b: 1.0,
+                },
+                0.0,
+                0,
+                0,
+                off,
+                total,
+            );
+            p.edge_offset = off;
+            self.queue
+                .write_buffer(&self.params_buffer, 0, bytemuck::cast_slice(&[p]));
+            self.dispatch(
+                &self.rebase_pipeline,
+                &self.rebase_bind_group,
+                count.div_ceil(256),
+                "rebase",
+            );
+            off += count;
+        }
     }
 
-    /// Create a bind group with all 4 bindings.
-    fn create_bind_group(&self, label: &str) -> wgpu::BindGroup {
-        self.device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some(label),
-            layout: &self.bind_group_layout,
-            entries: &[
-                wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: self.embedding_buffer.as_entire_binding(),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 1,
-                    resource: self.edges_buffer.as_entire_binding(),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 2,
-                    resource: self.params_buffer.as_entire_binding(),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 3,
-                    resource: self.grad_accum_buffer.as_entire_binding(),
-                },
-            ],
-        })
-    }
-
-    /// Download the final embedding from the GPU.
-    async fn download_embedding(&self) -> Vec<f32> {
+    /// Download the embedding from the GPU into a fresh Vec.
+    pub async fn download_embedding(&self) -> Vec<f32> {
         let size = (self.n_vertices as u64) * (self.dim as u64) * 4;
 
         let mut encoder = self
@@ -513,117 +667,4 @@ impl OptimizeGpuContext {
         self.embedding_staging.unmap();
         result
     }
-}
-
-/// GPU-accelerated version of `optimize_layout_euclidean`.
-///
-/// Returns `Some(())` on success, `None` if GPU is unavailable.
-/// The epoch scheduling logic is identical to the CPU version.
-#[allow(clippy::too_many_arguments)]
-pub async fn optimize_layout_gpu(
-    embedding: &mut Array2<f32>,
-    head: &[usize],
-    tail: &[usize],
-    epochs_per_sample: &[f32],
-    n_epochs: usize,
-    n_vertices: usize,
-    n_neighbors: usize,
-    a: f64,
-    b: f64,
-    gamma: f32,
-    initial_alpha: f32,
-    negative_sample_rate: f32,
-    rng_state: [i64; 3],
-    logger: &mut Logger,
-) -> Option<()> {
-    let dim = embedding.ncols();
-    let n_edges = head.len();
-
-    let emb_slice = embedding.as_slice().expect("embedding not contiguous");
-
-    let ctx = OptimizeGpuContext::new(emb_slice, n_vertices as u32, dim as u32).await?;
-
-    logger.log("Using GPU for layout optimization");
-
-    let a_f32 = a as f32;
-    let b_f32 = b as f32;
-
-    // Accumulated gradient clamp, derived from n_neighbors.
-    // Each vertex receives ~7K gradient contributions per epoch (K as head,
-    // K as tail for attractive, ~5K for repulsive with negative_sample_rate=5).
-    // Since contributions point in different directions, the expected magnitude
-    // per component scales as sqrt(N) (random walk). We clamp at
-    // EDGE_CLAMP * sqrt(7 * K) to allow normal accumulation while preventing
-    // extreme outliers from overshooting.
-    let edge_clamp = 4.0f32;
-    let grad_clamp = edge_clamp * (7.0 * n_neighbors as f32).sqrt();
-
-    let epochs_per_negative_sample: Vec<f32> = epochs_per_sample
-        .iter()
-        .map(|&e| e / negative_sample_rate)
-        .collect();
-    let mut epoch_of_next_sample = epochs_per_sample.to_vec();
-    let mut epoch_of_next_negative_sample = epochs_per_negative_sample.clone();
-
-    // Base seed for per-edge RNG on GPU
-    let base_seed = (rng_state[0] as u32)
-        .wrapping_add(rng_state[1] as u32)
-        .wrapping_add(rng_state[2] as u32);
-
-    let mut packed_edges: Vec<u32> = Vec::new();
-
-    for epoch in 0..n_epochs {
-        let alpha = initial_alpha * (1.0 - epoch as f32 / n_epochs as f32);
-
-        // Phase 1: Collect active edges (same logic as CPU)
-        packed_edges.clear();
-        let mut n_active = 0usize;
-        for i in 0..n_edges {
-            if epoch_of_next_sample[i] > epoch as f32 {
-                continue;
-            }
-
-            let n_neg = ((epoch as f32 - epoch_of_next_negative_sample[i])
-                / epochs_per_negative_sample[i]) as u32;
-
-            // Per-edge RNG seed: deterministic from (base_seed, edge_idx, epoch)
-            let rng_seed = base_seed
-                .wrapping_mul(epoch as u32 + 1)
-                .wrapping_add(i as u32 * 2654435761);
-
-            packed_edges.push(head[i] as u32);
-            packed_edges.push(tail[i] as u32);
-            packed_edges.push(n_neg);
-            packed_edges.push(rng_seed);
-            n_active += 1;
-
-            epoch_of_next_sample[i] += epochs_per_sample[i];
-            epoch_of_next_negative_sample[i] += n_neg as f32 * epochs_per_negative_sample[i];
-        }
-
-        // Phase 2: Dispatch to GPU (atomic gradient accumulation)
-        ctx.run_epoch(
-            &packed_edges,
-            n_active,
-            alpha,
-            a_f32,
-            b_f32,
-            gamma,
-            grad_clamp,
-        );
-
-        if n_epochs >= 10 && epoch % (n_epochs / 10) == 0 {
-            logger.log(&format!("completed {} / {} epochs", epoch, n_epochs));
-        }
-        logger.stage_progress((epoch + 1) as f64 / n_epochs as f64, None);
-    }
-
-    // Download result
-    let result = ctx.download_embedding().await;
-    let emb_mut = embedding
-        .as_slice_memory_order_mut()
-        .expect("embedding not contiguous");
-    emb_mut.copy_from_slice(&result);
-
-    Some(())
 }

--- a/packages/umap/umap/src/graph.rs
+++ b/packages/umap/umap/src/graph.rs
@@ -1,109 +1,147 @@
 use ndarray::Array2;
 use rayon::prelude::*;
-use std::collections::HashMap;
 
 const SMOOTH_K_TOLERANCE: f64 = 1e-5;
 const MIN_K_DIST_SCALE: f32 = 1e-3;
 
-/// Sparse matrix in COO-like format backed by a HashMap for efficient lookups.
+/// Sparse weighted graph in CSR format (row-major; columns sorted ascending
+/// within each row). Built once from COO triples — the UMAP graph pipeline never
+/// needs incremental insertion — which lets `symmetrize`/`to_csr`/`to_edge_list`
+/// run on flat arrays instead of hashing millions of `(row, col)` keys.
 pub struct SparseMatrix {
-    pub entries: HashMap<(usize, usize), f32>,
+    pub indptr: Vec<usize>,
+    pub indices: Vec<usize>,
+    pub data: Vec<f32>,
     pub shape: (usize, usize),
 }
 
 impl SparseMatrix {
-    pub fn new(nrows: usize, ncols: usize) -> Self {
+    /// Build from COO triples. Columns are sorted ascending within each row, and
+    /// duplicate `(row, col)` pairs are collapsed (max weight) so each row has
+    /// unique, sorted columns — the pipeline never emits duplicates, but this
+    /// keeps `get`'s binary search and the CSR contract valid for any input.
+    pub fn from_coo(nrows: usize, ncols: usize, mut triples: Vec<(usize, usize, f32)>) -> Self {
+        triples.sort_unstable_by_key(|&(r, c, _)| (r, c));
+        let nnz = triples.len();
+        let mut indptr = vec![0usize; nrows + 1];
+        let mut indices = Vec::with_capacity(nnz);
+        let mut data = Vec::with_capacity(nnz);
+        let mut t = 0;
+        for r in 0..nrows {
+            while t < nnz && triples[t].0 == r {
+                let c = triples[t].1;
+                let mut v = triples[t].2;
+                t += 1;
+                while t < nnz && triples[t].0 == r && triples[t].1 == c {
+                    v = v.max(triples[t].2);
+                    t += 1;
+                }
+                indices.push(c);
+                data.push(v);
+            }
+            indptr[r + 1] = indices.len();
+        }
         SparseMatrix {
-            entries: HashMap::new(),
+            indptr,
+            indices,
+            data,
             shape: (nrows, ncols),
         }
     }
 
-    pub fn insert(&mut self, row: usize, col: usize, val: f32) {
-        if val != 0.0 {
-            self.entries.insert((row, col), val);
-        }
-    }
-
+    /// Look up A[row, col] (0.0 if absent). Columns are sorted, so binary search.
     pub fn get(&self, row: usize, col: usize) -> f32 {
-        *self.entries.get(&(row, col)).unwrap_or(&0.0)
+        let r = &self.indices[self.indptr[row]..self.indptr[row + 1]];
+        match r.binary_search(&col) {
+            Ok(k) => self.data[self.indptr[row] + k],
+            Err(_) => 0.0,
+        }
     }
 
-    /// Apply fuzzy set union: result = mix*(A + A^T - A*A^T) + (1-mix)*(A*A^T)
-    /// where A*A^T is element-wise product (Hadamard), not matrix multiplication.
+    /// Apply fuzzy set union: result = mix*(A + A^T - A∘A^T) + (1-mix)*(A∘A^T),
+    /// where A∘A^T is the element-wise (Hadamard) product. The result is
+    /// symmetric, so for each stored edge (i,j) the value at (j,i) is identical;
+    /// we emit the transpose entry only when A has no (j,i) of its own.
     pub fn symmetrize(&self, set_op_mix_ratio: f32) -> SparseMatrix {
-        let mut result = SparseMatrix::new(self.shape.0, self.shape.1);
         let mix = set_op_mix_ratio as f64;
-
-        // Collect all unique (i,j) pairs considering both A[i,j] and A[j,i]
-        let mut pairs: std::collections::HashSet<(usize, usize)> = std::collections::HashSet::new();
-        for &(r, c) in self.entries.keys() {
-            pairs.insert((r, c));
-            pairs.insert((c, r));
-        }
-
-        for (i, j) in pairs {
-            let a_ij = self.get(i, j) as f64;
-            let a_ji = self.get(j, i) as f64;
-            let prod = a_ij * a_ji;
-            let val = mix * (a_ij + a_ji - prod) + (1.0 - mix) * prod;
-            if val > 0.0 {
-                result.insert(i, j, val as f32);
+        let n = self.shape.0;
+        let mut triples: Vec<(usize, usize, f32)> = Vec::with_capacity(self.data.len() * 2);
+        for i in 0..n {
+            for p in self.indptr[i]..self.indptr[i + 1] {
+                let j = self.indices[p];
+                let a_ij = self.data[p] as f64;
+                let a_ji = self.get(j, i) as f64;
+                let prod = a_ij * a_ji;
+                let val = mix * (a_ij + a_ji - prod) + (1.0 - mix) * prod;
+                if val > 0.0 {
+                    triples.push((i, j, val as f32));
+                    // The reverse edge isn't in A, so it won't be visited on its
+                    // own pass — emit it here to keep the result symmetric.
+                    if a_ji == 0.0 {
+                        triples.push((j, i, val as f32));
+                    }
+                }
             }
         }
-
-        result
+        SparseMatrix::from_coo(n, self.shape.1, triples)
     }
 
     /// Remove entries below threshold.
     pub fn prune(&mut self, threshold: f32) {
-        self.entries.retain(|_, v| *v >= threshold);
-    }
-
-    /// Convert to CSR format for efficient row access.
-    pub fn to_csr(&self) -> CsrMatrix {
         let n = self.shape.0;
-        let mut row_entries: Vec<Vec<(usize, f32)>> = vec![Vec::new(); n];
-        for (&(r, c), &v) in &self.entries {
-            row_entries[r].push((c, v));
-        }
-        // Sort each row by column index
-        for row in &mut row_entries {
-            row.sort_by_key(|&(c, _)| c);
-        }
-
         let mut indptr = Vec::with_capacity(n + 1);
-        let mut indices = Vec::new();
-        let mut data = Vec::new();
+        let mut indices = Vec::with_capacity(self.indices.len());
+        let mut data = Vec::with_capacity(self.data.len());
         indptr.push(0);
-        for row in &row_entries {
-            for &(c, v) in row {
-                indices.push(c);
-                data.push(v);
+        for i in 0..n {
+            for p in self.indptr[i]..self.indptr[i + 1] {
+                if self.data[p] >= threshold {
+                    indices.push(self.indices[p]);
+                    data.push(self.data[p]);
+                }
             }
             indptr.push(indices.len());
         }
+        self.indptr = indptr;
+        self.indices = indices;
+        self.data = data;
+    }
 
+    /// Largest edge weight (NEG_INFINITY if empty).
+    pub fn max_weight(&self) -> f32 {
+        self.data.iter().cloned().fold(f32::NEG_INFINITY, f32::max)
+    }
+
+    /// Number of stored edges.
+    pub fn nnz(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Convert to CSR format for efficient row access. The graph is already CSR,
+    /// so this is a copy into the standalone [`CsrMatrix`] type.
+    pub fn to_csr(&self) -> CsrMatrix {
         CsrMatrix {
-            indptr,
-            indices,
-            data,
+            indptr: self.indptr.clone(),
+            indices: self.indices.clone(),
+            data: self.data.clone(),
             nrows: self.shape.0,
             ncols: self.shape.1,
         }
     }
 
-    /// Extract edges as (head, tail, weight) arrays for the optimizer.
+    /// Extract edges as (head, tail, weight) arrays for the optimizer, in
+    /// row-major / column-sorted order.
     pub fn to_edge_list(&self) -> (Vec<usize>, Vec<usize>, Vec<f32>) {
-        let mut edges: Vec<_> = self.entries.iter().map(|(&(r, c), &v)| (r, c, v)).collect();
-        edges.sort_unstable_by_key(|&(r, c, _)| (r, c));
-        let mut heads = Vec::with_capacity(edges.len());
-        let mut tails = Vec::with_capacity(edges.len());
-        let mut weights = Vec::with_capacity(edges.len());
-        for (r, c, v) in edges {
-            heads.push(r);
-            tails.push(c);
-            weights.push(v);
+        let nnz = self.data.len();
+        let mut heads = Vec::with_capacity(nnz);
+        let mut tails = Vec::with_capacity(nnz);
+        let mut weights = Vec::with_capacity(nnz);
+        for i in 0..self.shape.0 {
+            for p in self.indptr[i]..self.indptr[i + 1] {
+                heads.push(i);
+                tails.push(self.indices[p]);
+                weights.push(self.data[p]);
+            }
         }
         (heads, tails, weights)
     }
@@ -310,14 +348,11 @@ pub fn compute_membership_strengths(
         })
         .collect();
 
-    let mut graph = SparseMatrix::new(n_samples, n_samples);
-    for batch in triples {
-        for (r, c, v) in batch {
-            graph.insert(r, c, v);
-        }
-    }
-
-    graph
+    SparseMatrix::from_coo(
+        n_samples,
+        n_samples,
+        triples.into_iter().flatten().collect(),
+    )
 }
 
 /// Build the fuzzy simplicial set from kNN data.
@@ -358,4 +393,149 @@ pub fn make_epochs_per_sample(weights: &[f32], n_epochs: usize) -> Vec<f32> {
             }
         })
         .collect()
+}
+
+/// Canonicalize a precomputed kNN graph into the form [`fuzzy_simplicial_set`]
+/// expects: column 0 is the point itself (distance 0) and the remaining columns
+/// are its neighbors, sorted ascending by distance.
+///
+/// # Caller's contract
+///
+/// This function canonicalizes the *layout* of a well-formed graph; it does **not**
+/// repair bad data and does not validate the input. The caller is responsible that,
+/// for every row `i`:
+/// - all neighbor indices are valid — in `[0, n_samples)` (no negative/`-1`
+///   "missing" padding);
+/// - `i` appears among its own neighbors **at most once** (self-inclusion is
+///   optional — this library and umap-learn put self in column 0, while
+///   faiss / scikit-learn / hnswlib exclude it — but it must not appear twice);
+/// - distances are finite (no `NaN`/`inf`).
+///
+/// Violating the contract degrades silently rather than erroring: a `NaN` distance
+/// sorts arbitrarily and can survive into the graph (yielding a `NaN` embedding),
+/// and because the output width is the *minimum* real-neighbor count across all
+/// rows (see below), a single short/ragged row trims every row down to its length.
+/// Keep the real-neighbor count uniform across rows.
+///
+/// # Canonicalization
+///
+/// Self-inclusion is detected and the graph is rewritten without ever fabricating a
+/// neighbor:
+/// - A row's *real* neighbors are the entries with `idx != i`, sorted ascending by
+///   `(distance, index)`. (Entries with `idx < 0` are skipped defensively, but per
+///   the contract there should be none.)
+/// - `m` is the minimum real-neighbor count across all rows.
+/// - The output is `(n, m + 1)`: column 0 is `(i, 0.0)`; columns `1..=m` are the
+///   `m` nearest real neighbors. Rows with more than `m` real neighbors drop their
+///   farthest ones, so every row keeps the same width with no padding.
+///
+/// For a contract-conforming graph this subsumes the three cases the boundary can
+/// see:
+/// - all rows exclude self → `m = k`, output width `k + 1` (self prepended);
+/// - all rows include self → `m = k - 1`, output width `k` (reordered, self leads);
+/// - mixed → `m = k - 1`, output width `k` (self-excluded rows drop one neighbor).
+///
+/// Already-canonical input (self in column 0, sorted) round-trips unchanged.
+pub fn normalize_knn_self_column(
+    indices: &Array2<i32>,
+    distances: &Array2<f32>,
+) -> (Array2<i32>, Array2<f32>) {
+    let n_samples = indices.nrows();
+    let n_neighbors = indices.ncols();
+
+    // Per row: real neighbors (idx >= 0, idx != self), sorted by ascending distance.
+    let per_row: Vec<Vec<(i32, f32)>> = (0..n_samples)
+        .map(|i| {
+            let mut neighbors: Vec<(i32, f32)> = (0..n_neighbors)
+                .filter_map(|j| {
+                    let idx = indices[[i, j]];
+                    if idx >= 0 && idx as usize != i {
+                        Some((idx, distances[[i, j]]))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            // Sort by (distance, index): the index tiebreak gives a deterministic
+            // order for equal distances. Distances are assumed finite per the
+            // contract; a NaN compares as Equal and would sort arbitrarily.
+            neighbors.sort_by(|a, b| {
+                a.1.partial_cmp(&b.1)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then(a.0.cmp(&b.0))
+            });
+            neighbors
+        })
+        .collect();
+
+    // m = the largest neighbor count keepable for every row without padding.
+    let m = per_row.iter().map(|r| r.len()).min().unwrap_or(0);
+
+    let out_cols = m + 1;
+    let mut out_indices = Array2::<i32>::zeros((n_samples, out_cols));
+    let mut out_distances = Array2::<f32>::zeros((n_samples, out_cols));
+    for (i, row) in per_row.iter().enumerate() {
+        out_indices[[i, 0]] = i as i32;
+        out_distances[[i, 0]] = 0.0;
+        for (col, &(idx, dist)) in row.iter().take(m).enumerate() {
+            out_indices[[i, col + 1]] = idx;
+            out_distances[[i, col + 1]] = dist;
+        }
+    }
+
+    (out_indices, out_distances)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::arr2;
+
+    #[test]
+    fn normalize_passthrough_when_already_canonical() {
+        // Self in column 0 (distance 0), neighbors already sorted ascending.
+        let idx = arr2(&[[0, 1, 2], [1, 0, 2], [2, 1, 0]]);
+        let dist = arr2(&[[0.0, 1.0, 2.0], [0.0, 1.0, 3.0], [0.0, 1.5, 2.5]]);
+        let (oi, od) = normalize_knn_self_column(&idx, &dist);
+        assert_eq!(oi, idx);
+        assert_eq!(od, dist);
+    }
+
+    #[test]
+    fn normalize_adds_self_when_excluded() {
+        // No row lists itself: width grows from k=2 to k+1=3, self prepended.
+        let idx = arr2(&[[1, 2], [0, 2], [0, 1]]);
+        let dist = arr2(&[[1.0, 2.0], [1.0, 3.0], [1.5, 2.5]]);
+        let (oi, od) = normalize_knn_self_column(&idx, &dist);
+        assert_eq!(oi.dim(), (3, 3));
+        assert_eq!(oi, arr2(&[[0, 1, 2], [1, 0, 2], [2, 0, 1]]));
+        assert_eq!(
+            od,
+            arr2(&[[0.0, 1.0, 2.0], [0.0, 1.0, 3.0], [0.0, 1.5, 2.5]])
+        );
+    }
+
+    #[test]
+    fn normalize_moves_self_to_front_and_sorts() {
+        // Self in the middle and neighbors out of order -> self leads, sorted.
+        let idx = arr2(&[[2, 0, 1], [2, 1, 0]]);
+        let dist = arr2(&[[2.0, 0.0, 1.0], [3.0, 0.0, 1.0]]);
+        let (oi, od) = normalize_knn_self_column(&idx, &dist);
+        assert_eq!(oi, arr2(&[[0, 1, 2], [1, 0, 2]]));
+        assert_eq!(od, arr2(&[[0.0, 1.0, 2.0], [0.0, 1.0, 3.0]]));
+    }
+
+    #[test]
+    fn normalize_mixed_trims_to_min_no_padding() {
+        // Row 0 includes self (2 real neighbors); row 1 excludes self (3 real).
+        // m = 2 -> output width 3 (= k); row 1 drops its farthest neighbor (idx 3, d=9).
+        let idx = arr2(&[[0, 1, 2], [0, 2, 3]]);
+        let dist = arr2(&[[0.0, 1.0, 2.0], [1.0, 4.0, 9.0]]);
+        let (oi, od) = normalize_knn_self_column(&idx, &dist);
+        assert_eq!(oi.dim(), (2, 3));
+        assert_eq!(oi, arr2(&[[0, 1, 2], [1, 0, 2]]));
+        assert_eq!(od, arr2(&[[0.0, 1.0, 2.0], [0.0, 1.0, 4.0]]));
+        // No fabricated (-1) entries anywhere.
+        assert!(oi.iter().all(|&v| v >= 0));
+    }
 }

--- a/packages/umap/umap/src/lib.rs
+++ b/packages/umap/umap/src/lib.rs
@@ -31,9 +31,13 @@ use nndescent::NNDescent;
 
 pub use nndescent::{Logger, ProgressCallback};
 
-use crate::graph::{fuzzy_simplicial_set, make_epochs_per_sample};
-use crate::optimize::optimize_layout_euclidean;
+use crate::graph::{
+    fuzzy_simplicial_set, make_epochs_per_sample, normalize_knn_self_column, CsrMatrix,
+    SparseMatrix,
+};
 use crate::spectral::{noisy_scale_coords, random_layout, spectral_layout};
+
+pub use crate::optimize::{LiveParams, Optimizer, UmapOptimizer};
 
 // ---------- UMAP stage definitions ----------
 
@@ -60,6 +64,13 @@ pub enum UmapError {
     NoNeighborGraph,
     /// Invalid parameter value.
     InvalidParameter(String),
+    /// Supplied kNN indices and distances have mismatched shapes.
+    KnnShapeMismatch {
+        indices: (usize, usize),
+        distances: (usize, usize),
+    },
+    /// A supplied kNN index is out of range `[0, n_samples)`.
+    KnnIndexOutOfRange { value: i32, n_samples: usize },
 }
 
 impl fmt::Display for UmapError {
@@ -68,6 +79,16 @@ impl fmt::Display for UmapError {
             UmapError::NNDescent(e) => write!(f, "NNDescent error: {}", e),
             UmapError::NoNeighborGraph => write!(f, "Neighbor graph was not computed"),
             UmapError::InvalidParameter(msg) => write!(f, "Invalid parameter: {}", msg),
+            UmapError::KnnShapeMismatch { indices, distances } => write!(
+                f,
+                "kNN indices shape {:?} does not match distances shape {:?}",
+                indices, distances
+            ),
+            UmapError::KnnIndexOutOfRange { value, n_samples } => write!(
+                f,
+                "kNN index {} out of range for {} samples",
+                value, n_samples
+            ),
         }
     }
 }
@@ -114,7 +135,10 @@ pub enum Init {
 ///     .unwrap();
 /// ```
 pub struct UmapBuilder<'a> {
-    data: &'a Array2<f32>,
+    data: Option<&'a Array2<f32>>,
+    /// Precomputed kNN graph (indices, distances). When set, NNDescent is skipped
+    /// and `data` is unused. See [`Umap::builder_from_knn`].
+    knn: Option<(Array2<i32>, Array2<f32>)>,
     n_neighbors: usize,
     n_components: usize,
     min_dist: f32,
@@ -130,6 +154,7 @@ pub struct UmapBuilder<'a> {
     verbose: bool,
     init: Init,
     gpu: bool,
+    optimizer: Optimizer,
     progress: Option<ProgressCallback>,
 }
 
@@ -233,97 +258,272 @@ impl<'a> UmapBuilder<'a> {
         self
     }
 
+    /// Optimizer to use for the layout SGD. Default: [`Optimizer::Sgd`].
+    pub fn optimizer(mut self, o: Optimizer) -> Self {
+        self.optimizer = o;
+        self
+    }
+
     /// Run UMAP and return the result (embedding + KNN graph).
     pub fn build(self) -> Result<UmapResult, UmapError> {
         pollster::block_on(self.build_async())
     }
 
-    /// Run UMAP asynchronously (for WASM with GPU).
+    /// Run UMAP asynchronously (for WASM with GPU): build the graph + initial
+    /// embedding, then optimize to completion. Output matches [`build`](Self::build).
     ///
-    /// On native, prefer [`build`] which handles async internally.
+    /// On native, prefer [`build`](Self::build) which handles async internally.
     pub async fn build_async(self) -> Result<UmapResult, UmapError> {
-        let data = self.data;
-        let n_samples = data.nrows();
+        let Prepared {
+            embedding,
+            graph: _,
+            knn_indices,
+            knn_distances,
+            head,
+            tail,
+            epochs_per_sample,
+            n_epochs,
+            n_neighbors,
+            rng_state,
+            params,
+            optimizer,
+            gpu,
+            mut logger,
+        } = self.prepare().await?;
 
-        if self.n_neighbors >= n_samples {
-            return Err(UmapError::InvalidParameter(format!(
-                "n_neighbors ({}) must be less than n_samples ({})",
-                self.n_neighbors, n_samples
-            )));
-        }
+        let mut engine = build_optimizer(
+            head,
+            tail,
+            epochs_per_sample,
+            embedding,
+            params,
+            optimizer,
+            rng_state,
+            gpu,
+            n_neighbors,
+        )
+        .await;
 
-        // Create logger
+        logger.push_stage_with_message(
+            STAGE_OPTIMIZATION,
+            &format!("Optimizing layout for {} epochs...", n_epochs),
+        );
+        engine.run_to(n_epochs, &mut logger).await;
+        logger.pop_stage();
+
+        Ok(UmapResult {
+            embedding: engine.into_embedding(),
+            knn_indices,
+            knn_distances,
+        })
+    }
+
+    /// Build the graph + initial embedding and return a resumable [`UmapSetup`],
+    /// **without** running the layout optimization. Use the returned
+    /// [`UmapOptimizer`] to step/run interactively.
+    pub async fn setup_async(self) -> Result<UmapSetup, UmapError> {
+        let Prepared {
+            embedding,
+            graph,
+            knn_indices,
+            knn_distances,
+            head,
+            tail,
+            epochs_per_sample,
+            n_epochs,
+            n_neighbors,
+            rng_state,
+            params,
+            optimizer,
+            gpu,
+            logger: _,
+        } = self.prepare().await?;
+
+        let optimizer = build_optimizer(
+            head,
+            tail,
+            epochs_per_sample,
+            embedding,
+            params,
+            optimizer,
+            rng_state,
+            gpu,
+            n_neighbors,
+        )
+        .await;
+
+        Ok(UmapSetup {
+            optimizer,
+            graph,
+            knn_indices,
+            knn_distances,
+            n_epochs,
+        })
+    }
+
+    /// Stages 1–7: nearest neighbors, fuzzy graph, prune, init, edge schedule.
+    /// Shared by [`build_async`](Self::build_async) and [`setup_async`](Self::setup_async).
+    async fn prepare(mut self) -> Result<Prepared, UmapError> {
+        // Take ownership of any supplied kNN graph up front, so the Step 1 branch
+        // below can move it without conflicting with the n_samples decision.
+        let knn = self.knn.take();
+
+        // n_samples comes from whichever input is present (kNN graph or data).
+        let n_samples = match &knn {
+            Some((idx, dist)) => {
+                if idx.shape() != dist.shape() {
+                    return Err(UmapError::KnnShapeMismatch {
+                        indices: idx.dim(),
+                        distances: dist.dim(),
+                    });
+                }
+                idx.nrows()
+            }
+            None => self
+                .data
+                .expect("UmapBuilder has neither data nor a kNN graph")
+                .nrows(),
+        };
+
         let mut logger = Logger::new(self.verbose, self.progress, UMAP_STAGES);
 
-        // Compute curve parameters a, b
+        // Degenerate inputs have nothing to embed: with 0 or 1 points there are no
+        // neighbor relationships to model. Return a trivial origin layout (empty
+        // graph/knn, zero epochs) rather than erroring, so callers don't have to
+        // special-case tiny datasets.
+        if n_samples <= 1 {
+            return Ok(Prepared {
+                embedding: Array2::zeros((n_samples, self.n_components)),
+                graph: SparseMatrix::from_coo(n_samples, n_samples, Vec::new()).to_csr(),
+                knn_indices: Array2::zeros((n_samples, 0)),
+                knn_distances: Array2::zeros((n_samples, 0)),
+                head: Vec::new(),
+                tail: Vec::new(),
+                epochs_per_sample: Vec::new(),
+                n_epochs: 0,
+                n_neighbors: 0,
+                rng_state: [0, 0, 0],
+                params: LiveParams {
+                    alpha: self.learning_rate,
+                    gamma: self.repulsion_strength,
+                    negative_sample_rate: self.negative_sample_rate as f32,
+                    a: 1.0,
+                    b: 1.0,
+                },
+                optimizer: self.optimizer,
+                gpu: self.gpu,
+                logger,
+            });
+        }
+
+        // Compute curve parameters a, b (independent of the neighbor count).
         let (a, b) = find_ab_params(self.spread, self.min_dist);
+
+        // Step 1: obtain the kNN graph — either supplied (skip NNDescent) or computed.
+        // We keep the STAGE_NEIGHBORS push/pop in both paths so a progress callback's
+        // stage fractions stay consistent (the supplied path reports it instantly).
+        logger.push_stage_with_message(STAGE_NEIGHBORS, "Finding nearest neighbors...");
+        let (knn_indices, knn_dists, n_neighbors) = match knn {
+            Some((idx, dist)) => {
+                // Validate indices; negatives are allowed and mean "missing".
+                for &v in idx.iter() {
+                    if v >= 0 && (v as usize) >= n_samples {
+                        return Err(UmapError::KnnIndexOutOfRange {
+                            value: v,
+                            n_samples,
+                        });
+                    }
+                }
+                // Canonicalize to self-at-column-0, sorted ascending; n_neighbors is
+                // taken from the (normalized) graph width, not self.n_neighbors.
+                let (norm_indices, norm_dists) = normalize_knn_self_column(&idx, &dist);
+                let n_neighbors = norm_indices.ncols();
+                logger.log("Using precomputed neighbors");
+                logger.pop_stage();
+                (norm_indices, norm_dists, n_neighbors)
+            }
+            None => {
+                let data = self
+                    .data
+                    .expect("UmapBuilder has neither data nor a kNN graph");
+
+                // A point can have at most `n_samples - 1` neighbors. Clamp rather
+                // than reject (mirrors umap-learn on small inputs).
+                let n_neighbors = self.n_neighbors.min(n_samples - 1);
+                if n_neighbors != self.n_neighbors {
+                    logger.log(&format!(
+                        "n_neighbors ({}) >= n_samples ({}); clamping to {}",
+                        self.n_neighbors, n_samples, n_neighbors
+                    ));
+                }
+
+                // Create nndescent callback that forwards to our logger's user callback.
+                // We share the user callback between the UMAP logger and the NNDescent
+                // sub-callback via Rc<RefCell<>>, avoiding unsafe pointer aliasing.
+                let nn_cb: Option<nndescent::ProgressCallback> = if logger.callback.is_some() {
+                    use std::cell::RefCell;
+                    use std::rc::Rc;
+
+                    let user_cb = Rc::new(RefCell::new(logger.callback.take().unwrap()));
+
+                    // Replace logger's callback with a delegating wrapper
+                    let logger_cb = user_cb.clone();
+                    logger.callback = Some(Box::new(move |progress: f32, stage: &str| {
+                        (*logger_cb.borrow_mut())(progress, stage);
+                    }));
+
+                    // Compute the NEIGHBORS stage progress mapping from UMAP_STAGES
+                    let (stage_start, stage_frac) = {
+                        let mut cumulative = 0.0f32;
+                        let mut found = (0.0f32, 1.0f32);
+                        for &(name, frac) in UMAP_STAGES {
+                            if name == STAGE_NEIGHBORS {
+                                found = (cumulative, frac);
+                                break;
+                            }
+                            cumulative += frac;
+                        }
+                        found
+                    };
+
+                    // Create NNDescent callback that maps sub-progress to overall UMAP progress
+                    let nn_cb_ref = user_cb.clone();
+                    Some(Box::new(move |progress: f32, stage: &str| {
+                        let label = format!("NNDescent: {}", stage);
+                        let overall = (stage_start + stage_frac * progress).min(1.0);
+                        (*nn_cb_ref.borrow_mut())(overall, &label);
+                    }))
+                } else {
+                    None
+                };
+
+                let mut nnd_builder = NNDescent::builder(data.clone(), &self.metric, n_neighbors)
+                    .verbose(self.verbose)
+                    .gpu(self.gpu)
+                    .progress_option(nn_cb);
+                if let Some(seed) = self.random_state {
+                    nnd_builder = nnd_builder.random_state(seed);
+                }
+                let nnd = nnd_builder.build_async().await?;
+                let (knn_indices, knn_dists) =
+                    nnd.neighbor_graph().ok_or(UmapError::NoNeighborGraph)?;
+                logger.pop_stage();
+                (knn_indices, knn_dists, n_neighbors)
+            }
+        };
 
         logger.log(&format!(
             "UMAP(n_neighbors={}, n_components={}, metric={})",
-            self.n_neighbors, self.n_components, self.metric
+            n_neighbors, self.n_components, self.metric
         ));
         logger.log(&format!("Fitted a={:.4}, b={:.4}", a, b));
-
-        // Step 1: Compute nearest neighbors using NNDescent
-        logger.push_stage_with_message(STAGE_NEIGHBORS, "Finding nearest neighbors...");
-
-        // Create nndescent callback that forwards to our logger's user callback.
-        // We share the user callback between the UMAP logger and the NNDescent
-        // sub-callback via Rc<RefCell<>>, avoiding unsafe pointer aliasing.
-        let nn_cb: Option<nndescent::ProgressCallback> = if logger.callback.is_some() {
-            use std::cell::RefCell;
-            use std::rc::Rc;
-
-            let user_cb = Rc::new(RefCell::new(logger.callback.take().unwrap()));
-
-            // Replace logger's callback with a delegating wrapper
-            let logger_cb = user_cb.clone();
-            logger.callback = Some(Box::new(move |progress: f32, stage: &str| {
-                (*logger_cb.borrow_mut())(progress, stage);
-            }));
-
-            // Compute the NEIGHBORS stage progress mapping from UMAP_STAGES
-            let (stage_start, stage_frac) = {
-                let mut cumulative = 0.0f32;
-                let mut found = (0.0f32, 1.0f32);
-                for &(name, frac) in UMAP_STAGES {
-                    if name == STAGE_NEIGHBORS {
-                        found = (cumulative, frac);
-                        break;
-                    }
-                    cumulative += frac;
-                }
-                found
-            };
-
-            // Create NNDescent callback that maps sub-progress to overall UMAP progress
-            let nn_cb_ref = user_cb.clone();
-            Some(Box::new(move |progress: f32, stage: &str| {
-                let label = format!("NNDescent: {}", stage);
-                let overall = (stage_start + stage_frac * progress).min(1.0);
-                (*nn_cb_ref.borrow_mut())(overall, &label);
-            }))
-        } else {
-            None
-        };
-
-        let mut nnd_builder = NNDescent::builder(data.clone(), &self.metric, self.n_neighbors)
-            .verbose(self.verbose)
-            .gpu(self.gpu)
-            .progress_option(nn_cb);
-        if let Some(seed) = self.random_state {
-            nnd_builder = nnd_builder.random_state(seed);
-        }
-        let nnd = nnd_builder.build_async().await?;
-        let (knn_indices, knn_dists) = nnd.neighbor_graph().ok_or(UmapError::NoNeighborGraph)?;
-        logger.pop_stage();
 
         // Step 2: Build fuzzy simplicial set
         logger.push_stage_with_message(STAGE_GRAPH, "Constructing fuzzy simplicial set...");
         let mut graph = fuzzy_simplicial_set(
             &knn_indices,
             &knn_dists,
-            self.n_neighbors,
+            n_neighbors,
             self.set_op_mix_ratio,
             self.local_connectivity,
         );
@@ -335,15 +535,14 @@ impl<'a> UmapBuilder<'a> {
 
         // Step 4: Prune weak edges
         if n_epochs > 10 {
-            let max_weight = graph
-                .entries
-                .values()
-                .cloned()
-                .fold(f32::NEG_INFINITY, f32::max);
+            let max_weight = graph.max_weight();
             let threshold = max_weight / n_epochs as f32;
             graph.prune(threshold);
         }
         logger.pop_stage();
+
+        // CSR of the pruned graph: used for spectral init and retained for reset.
+        let csr = graph.to_csr();
 
         // Step 5: Initialize embedding
         logger.push_stage_with_message(STAGE_EMBEDDING_INIT, "Initializing embedding...");
@@ -352,9 +551,16 @@ impl<'a> UmapBuilder<'a> {
             None => Xoshiro256StarStar::seed_from_os(),
         };
 
-        let mut embedding = match self.init {
+        // Spectral init hurts momentum early (and costs LOBPCG time); prefer random
+        // when momentum is selected. (Single-line guard; see plan §5.)
+        let init = if self.optimizer == Optimizer::Momentum {
+            Init::Random
+        } else {
+            self.init.clone()
+        };
+
+        let embedding = match init {
             Init::Spectral => {
-                let csr = graph.to_csr();
                 logger.log("Computing spectral initialization...");
                 let mut emb = spectral_layout(&csr, self.n_components, &mut rng);
                 let is_random_fallback = {
@@ -384,85 +590,109 @@ impl<'a> UmapBuilder<'a> {
             rng.random_i64().abs(),
         ];
 
-        // Step 8: Optimize embedding
-        logger.push_stage_with_message(
-            STAGE_OPTIMIZATION,
-            &format!("Optimizing layout for {} epochs...", n_epochs),
-        );
-
-        #[cfg(feature = "gpu")]
-        let used_gpu = if self.gpu {
-            match crate::gpu_optimize::optimize_layout_gpu(
-                &mut embedding,
-                &heads,
-                &tails,
-                &epochs_per_sample,
-                n_epochs,
-                n_samples,
-                self.n_neighbors,
-                a,
-                b,
-                self.repulsion_strength,
-                self.learning_rate,
-                self.negative_sample_rate as f32,
-                rng_state,
-                &mut logger,
-            )
-            .await
-            {
-                Some(()) => true,
-                None => {
-                    logger.log("GPU unavailable for optimization, falling back to CPU");
-                    false
-                }
-            }
-        } else {
-            false
-        };
-
-        #[cfg(feature = "gpu")]
-        if !used_gpu {
-            optimize_layout_euclidean(
-                &mut embedding,
-                &heads,
-                &tails,
-                &epochs_per_sample,
-                n_epochs,
-                n_samples,
-                a,
-                b,
-                self.repulsion_strength,
-                self.learning_rate,
-                self.negative_sample_rate as f32,
-                rng_state,
-                &mut logger,
-            );
-        }
-
-        #[cfg(not(feature = "gpu"))]
-        optimize_layout_euclidean(
-            &mut embedding,
-            &heads,
-            &tails,
-            &epochs_per_sample,
-            n_epochs,
-            n_samples,
-            a,
-            b,
-            self.repulsion_strength,
-            self.learning_rate,
-            self.negative_sample_rate as f32,
-            rng_state,
-            &mut logger,
-        );
-        logger.pop_stage();
-
-        Ok(UmapResult {
+        Ok(Prepared {
             embedding,
+            graph: csr,
             knn_indices,
             knn_distances: knn_dists,
+            head: heads,
+            tail: tails,
+            epochs_per_sample,
+            n_epochs,
+            n_neighbors,
+            rng_state,
+            params: LiveParams {
+                alpha: self.learning_rate,
+                gamma: self.repulsion_strength,
+                negative_sample_rate: self.negative_sample_rate as f32,
+                a: a as f32,
+                b: b as f32,
+            },
+            optimizer: self.optimizer,
+            gpu: self.gpu,
+            logger,
         })
     }
+}
+
+/// Construct a [`UmapOptimizer`] from prepared pieces, using the resident GPU
+/// context when `gpu` is requested and the `gpu` feature is enabled (falls back
+/// to CPU otherwise).
+#[allow(clippy::too_many_arguments)]
+async fn build_optimizer(
+    head: Vec<usize>,
+    tail: Vec<usize>,
+    epochs_per_sample: Vec<f32>,
+    embedding: Array2<f32>,
+    params: LiveParams,
+    optimizer: Optimizer,
+    rng_state: [i64; 3],
+    gpu: bool,
+    n_neighbors: usize,
+) -> UmapOptimizer {
+    #[cfg(feature = "gpu")]
+    {
+        if gpu {
+            return UmapOptimizer::new_gpu(
+                head,
+                tail,
+                &epochs_per_sample,
+                embedding,
+                params,
+                optimizer,
+                rng_state,
+                n_neighbors,
+            )
+            .await;
+        }
+    }
+    #[cfg(not(feature = "gpu"))]
+    {
+        let _ = (gpu, n_neighbors);
+    }
+    UmapOptimizer::new(
+        head,
+        tail,
+        &epochs_per_sample,
+        embedding,
+        params,
+        optimizer,
+        rng_state,
+    )
+}
+
+/// Output of [`UmapBuilder::prepare`]: everything needed to construct the
+/// optimizer plus the retained pruned graph and kNN arrays.
+struct Prepared {
+    embedding: Array2<f32>,
+    graph: CsrMatrix,
+    knn_indices: Array2<i32>,
+    knn_distances: Array2<f32>,
+    head: Vec<usize>,
+    tail: Vec<usize>,
+    epochs_per_sample: Vec<f32>,
+    n_epochs: usize,
+    n_neighbors: usize,
+    rng_state: [i64; 3],
+    params: LiveParams,
+    optimizer: Optimizer,
+    gpu: bool,
+    logger: Logger,
+}
+
+/// A prepared, not-yet-optimized UMAP: the resumable optimizer plus the retained
+/// graph and kNN arrays. Returned by [`UmapBuilder::setup_async`].
+pub struct UmapSetup {
+    /// The resumable layout optimizer (already holds the initial embedding).
+    pub optimizer: UmapOptimizer,
+    /// The pruned fuzzy graph (CSR), retained for spectral re-initialization.
+    pub graph: CsrMatrix,
+    /// KNN indices from the neighbor graph, shape (n_samples, n_neighbors).
+    pub knn_indices: Array2<i32>,
+    /// KNN distances from the neighbor graph, shape (n_samples, n_neighbors).
+    pub knn_distances: Array2<f32>,
+    /// The nominal optimization horizon (default 500/200).
+    pub n_epochs: usize,
 }
 
 /// Result of a UMAP computation.
@@ -485,7 +715,8 @@ impl Umap {
     /// * `data` - Array of shape (n_samples, n_features)
     pub fn builder(data: &Array2<f32>) -> UmapBuilder<'_> {
         UmapBuilder {
-            data,
+            data: Some(data),
+            knn: None,
             n_neighbors: 15,
             n_components: 2,
             min_dist: 0.1,
@@ -501,6 +732,54 @@ impl Umap {
             verbose: false,
             init: Init::Spectral,
             gpu: false,
+            optimizer: Optimizer::Sgd,
+            progress: None,
+        }
+    }
+
+    /// Create a builder from a precomputed kNN graph, skipping NNDescent. No
+    /// high-dimensional data is needed — once the graph exists, UMAP uses only it.
+    ///
+    /// `knn_indices` and `knn_distances` are both shape (n_samples, k), where row
+    /// `i` lists the neighbors of point `i` sorted by ascending distance. The point
+    /// itself may be included (typically column 0, distance 0) or omitted — this is
+    /// detected and normalized per row (see [`normalize_knn_self_column`]). `metric`
+    /// and `n_neighbors` are ignored in this mode (k is taken from the supplied
+    /// graph).
+    ///
+    /// The caller is responsible for supplying a well-formed graph; it is not
+    /// validated beyond an index-range check, and bad input degrades silently:
+    /// - every neighbor index must be valid (in `[0, n_samples)`);
+    /// - point `i` may list itself at most once per row;
+    /// - distances must be finite (a `NaN` propagates to a `NaN` embedding);
+    /// - the real-neighbor count should be uniform across rows — the canonical
+    ///   width is the per-row minimum, so one short row trims every row (see
+    ///   [`normalize_knn_self_column`]).
+    ///
+    /// [`normalize_knn_self_column`]: crate::graph::normalize_knn_self_column
+    pub fn builder_from_knn(
+        knn_indices: Array2<i32>,
+        knn_distances: Array2<f32>,
+    ) -> UmapBuilder<'static> {
+        UmapBuilder {
+            data: None,
+            knn: Some((knn_indices, knn_distances)),
+            n_neighbors: 15,
+            n_components: 2,
+            min_dist: 0.1,
+            spread: 1.0,
+            metric: "euclidean".to_string(),
+            n_epochs: None,
+            learning_rate: 1.0,
+            negative_sample_rate: 5,
+            repulsion_strength: 1.0,
+            local_connectivity: 1.0,
+            set_op_mix_ratio: 1.0,
+            random_state: None,
+            verbose: false,
+            init: Init::Spectral,
+            gpu: false,
+            optimizer: Optimizer::Sgd,
             progress: None,
         }
     }
@@ -514,7 +793,7 @@ impl Umap {
 ///   y = exp(-(x - min_dist) / spread)  otherwise
 ///
 /// Uses Levenberg-Marquardt optimization (damped Gauss-Newton).
-fn find_ab_params(spread: f32, min_dist: f32) -> (f64, f64) {
+pub fn find_ab_params(spread: f32, min_dist: f32) -> (f64, f64) {
     let n = 300;
     let spread = spread as f64;
     let min_dist = min_dist as f64;
@@ -638,11 +917,134 @@ fn find_ab_params(spread: f32, min_dist: f32) -> (f64, f64) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ndarray::Array2;
+    use ndarray::{arr2, s, Array2};
 
     fn make_test_data(n: usize, dim: usize, seed: u64) -> Array2<f32> {
         let mut rng = Xoshiro256StarStar::seed_from_u64(seed);
         Array2::from_shape_fn((n, dim), |_| rng.random_f32())
+    }
+
+    /// Exact euclidean kNN in the umap-learn layout: row i lists point i itself in
+    /// column 0 (distance 0), then its `k-1` nearest neighbors sorted ascending.
+    fn make_knn(data: &Array2<f32>, k: usize) -> (Array2<i32>, Array2<f32>) {
+        let n = data.nrows();
+        let mut indices = Array2::<i32>::zeros((n, k));
+        let mut distances = Array2::<f32>::zeros((n, k));
+        for i in 0..n {
+            let mut dists: Vec<(f32, usize)> = (0..n)
+                .map(|j| {
+                    let d2: f32 = data
+                        .row(i)
+                        .iter()
+                        .zip(data.row(j).iter())
+                        .map(|(a, b)| (a - b) * (a - b))
+                        .sum();
+                    (d2.sqrt(), j)
+                })
+                .collect();
+            dists.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap().then(a.1.cmp(&b.1)));
+            for c in 0..k {
+                indices[[i, c]] = dists[c].1 as i32;
+                distances[[i, c]] = dists[c].0;
+            }
+        }
+        (indices, distances)
+    }
+
+    #[test]
+    fn test_umap_from_knn_shape() {
+        let data = make_test_data(200, 10, 42);
+        let (idx, dist) = make_knn(&data, 11); // self + 10 neighbors
+        let result = Umap::builder_from_knn(idx, dist)
+            .n_epochs(50)
+            .init_method(Init::Random)
+            .random_state(42)
+            .build()
+            .unwrap();
+
+        assert_eq!(result.embedding.nrows(), 200);
+        assert_eq!(result.embedding.ncols(), 2);
+        assert!(result.embedding.iter().all(|x| x.is_finite()));
+        // Self already in column 0 -> the echoed graph keeps its width.
+        assert_eq!(result.knn_indices.dim(), (200, 11));
+        assert_eq!(result.knn_distances.dim(), (200, 11));
+    }
+
+    #[test]
+    fn test_umap_from_knn_self_excluded_widens() {
+        let data = make_test_data(150, 8, 7);
+        let (idx, dist) = make_knn(&data, 11);
+        // Drop column 0 (self) from every row -> self-excluded, width 10.
+        let idx_ex = idx.slice(s![.., 1..]).to_owned();
+        let dist_ex = dist.slice(s![.., 1..]).to_owned();
+        let result = Umap::builder_from_knn(idx_ex, dist_ex)
+            .n_epochs(30)
+            .init_method(Init::Random)
+            .random_state(7)
+            .build()
+            .unwrap();
+
+        assert_eq!(result.embedding.nrows(), 150);
+        // Self was re-added -> width grows back to 11.
+        assert_eq!(result.knn_indices.ncols(), 11);
+        assert!(result.embedding.iter().all(|x| x.is_finite()));
+    }
+
+    #[test]
+    fn test_umap_from_knn_shape_mismatch() {
+        let idx = Array2::<i32>::zeros((10, 5));
+        let dist = Array2::<f32>::zeros((10, 6));
+        let err = Umap::builder_from_knn(idx, dist)
+            .build()
+            .err()
+            .expect("expected a shape-mismatch error");
+        assert!(matches!(err, UmapError::KnnShapeMismatch { .. }));
+    }
+
+    #[test]
+    fn test_umap_from_knn_index_out_of_range() {
+        // n_samples = 3, but a row references index 5.
+        let idx = arr2(&[[0, 1, 2], [1, 0, 2], [2, 5, 0]]);
+        let dist = arr2(&[[0.0, 1.0, 2.0], [0.0, 1.0, 2.0], [0.0, 1.0, 2.0]]);
+        let err = Umap::builder_from_knn(idx, dist)
+            .build()
+            .err()
+            .expect("expected an out-of-range error");
+        assert!(matches!(
+            err,
+            UmapError::KnnIndexOutOfRange {
+                value: 5,
+                n_samples: 3
+            }
+        ));
+    }
+
+    #[test]
+    fn test_umap_from_knn_negative_index_ok() {
+        // Negative indices are outside the documented contract (callers should
+        // supply only valid neighbors), but are tolerated defensively: a `-1`
+        // entry is skipped rather than crashing or being treated as vertex -1.
+        let data = make_test_data(60, 6, 11);
+        let (mut idx, dist) = make_knn(&data, 8);
+        idx[[0, 7]] = -1; // out-of-contract entry; must be skipped, not crash
+        let result = Umap::builder_from_knn(idx, dist)
+            .n_epochs(20)
+            .init_method(Init::Random)
+            .random_state(11)
+            .build();
+        assert!(result.is_ok());
+        assert!(result.unwrap().embedding.iter().all(|x| x.is_finite()));
+    }
+
+    #[test]
+    fn test_umap_from_knn_single_point() {
+        // 1 row: degenerate trivial origin layout (mirrors test_umap_single_point).
+        let idx = Array2::<i32>::zeros((1, 1));
+        let dist = Array2::<f32>::zeros((1, 1));
+        let result = Umap::builder_from_knn(idx, dist).build().unwrap();
+        assert_eq!(result.embedding.nrows(), 1);
+        assert_eq!(result.embedding.ncols(), 2);
+        assert!(result.embedding.iter().all(|&x| x == 0.0));
     }
 
     #[test]
@@ -754,5 +1156,372 @@ mod tests {
 
         assert_eq!(result.embedding.nrows(), 100);
         assert!(!result.embedding.iter().any(|x| x.is_nan()));
+    }
+
+    #[test]
+    fn test_umap_small_dataset_clamps_neighbors() {
+        // Fewer rows than the default n_neighbors (15). Previously this errored;
+        // now n_neighbors is clamped to n_samples - 1 and the run succeeds.
+        let data = make_test_data(5, 8, 42);
+        let result = Umap::builder(&data)
+            .metric("cosine")
+            .random_state(42)
+            .build()
+            .unwrap();
+
+        assert_eq!(result.embedding.nrows(), 5);
+        assert_eq!(result.embedding.ncols(), 2);
+        assert!(result.embedding.iter().all(|x| x.is_finite()));
+    }
+
+    #[test]
+    fn test_umap_two_points() {
+        // Smallest non-degenerate input: n_neighbors clamps to 1.
+        let data = make_test_data(2, 4, 42);
+        let result = Umap::builder(&data).random_state(42).build().unwrap();
+
+        assert_eq!(result.embedding.nrows(), 2);
+        assert_eq!(result.embedding.ncols(), 2);
+        assert!(result.embedding.iter().all(|x| x.is_finite()));
+    }
+
+    #[test]
+    fn test_umap_single_point() {
+        // 1 row: nothing to embed, returns a trivial origin layout.
+        let data = make_test_data(1, 4, 42);
+        let result = Umap::builder(&data).build().unwrap();
+
+        assert_eq!(result.embedding.nrows(), 1);
+        assert_eq!(result.embedding.ncols(), 2);
+        assert!(result.embedding.iter().all(|&x| x == 0.0));
+    }
+
+    #[test]
+    fn test_umap_empty() {
+        // 0 rows: returns an empty embedding rather than erroring.
+        let data = make_test_data(0, 4, 42);
+        let result = Umap::builder(&data).build().unwrap();
+
+        assert_eq!(result.embedding.nrows(), 0);
+        assert_eq!(result.embedding.ncols(), 2);
+    }
+
+    #[test]
+    fn test_stepper_advances() {
+        let data = make_test_data(200, 10, 42);
+        let mut setup = pollster::block_on(
+            Umap::builder(&data)
+                .n_neighbors(10)
+                .n_epochs(50)
+                .init_method(Init::Random)
+                .random_state(42)
+                .setup_async(),
+        )
+        .unwrap();
+
+        assert_eq!(setup.optimizer.current_epoch(), 0);
+        let before = setup.optimizer.embedding().clone();
+
+        pollster::block_on(setup.optimizer.step(10));
+
+        assert_eq!(setup.optimizer.current_epoch(), 10);
+        let after = setup.optimizer.embedding();
+        assert_eq!(after.nrows(), 200);
+        assert_eq!(after.ncols(), 2);
+        assert!(!after.iter().any(|x| x.is_nan()));
+
+        let moved = before
+            .iter()
+            .zip(after.iter())
+            .any(|(a, b)| (a - b).abs() > 1e-6);
+        assert!(moved, "step did not move the embedding");
+    }
+
+    #[test]
+    fn test_set_optimizer_and_reinit_finite() {
+        let data = make_test_data(150, 8, 7);
+        let mut setup = pollster::block_on(
+            Umap::builder(&data)
+                .n_neighbors(10)
+                .n_epochs(30)
+                .init_method(Init::Random)
+                .random_state(7)
+                .setup_async(),
+        )
+        .unwrap();
+
+        setup.optimizer.set_optimizer(Optimizer::Momentum);
+        pollster::block_on(setup.optimizer.step(20));
+        assert!(setup.optimizer.embedding().iter().all(|x| x.is_finite()));
+
+        let mut rng = Xoshiro256StarStar::seed_from_u64(7);
+        let fresh = random_layout(150, 2, &mut rng);
+        setup.optimizer.reinit_embedding(fresh);
+        assert_eq!(setup.optimizer.current_epoch(), 0);
+
+        pollster::block_on(setup.optimizer.step(5));
+        assert!(setup.optimizer.embedding().iter().all(|x| x.is_finite()));
+    }
+
+    #[test]
+    fn test_live_negative_sample_rate_reenables_repulsion() {
+        // Regression: starting at negative_sample_rate = 0 and then raising it via
+        // set_params must actually turn repulsion back on. Previously the per-edge
+        // negative-sample counter was parked at +inf (CPU) / a stale baseline (GPU)
+        // and a live rate change never re-armed it, so repulsion stayed off.
+        //
+        // Two optimizers step identically with repulsion off; then one enables it
+        // live. Repulsion spreads points apart, so the enabled run must end with a
+        // visibly larger layout than the still-attract-only reference.
+        let build = || {
+            pollster::block_on(
+                Umap::builder(&make_test_data(200, 10, 99))
+                    .n_neighbors(10)
+                    .n_epochs(100)
+                    .init_method(Init::Random)
+                    .negative_sample_rate(0)
+                    .random_state(99)
+                    .setup_async(),
+            )
+            .unwrap()
+        };
+        let mut on = build();
+        let mut off = build();
+
+        // Identical attract-only warmup.
+        pollster::block_on(on.optimizer.step(30));
+        pollster::block_on(off.optimizer.step(30));
+
+        // Enable repulsion live on one of them.
+        let mut p = on.optimizer.params();
+        p.negative_sample_rate = 5.0;
+        on.optimizer.set_params(p);
+
+        pollster::block_on(on.optimizer.step(40));
+        pollster::block_on(off.optimizer.step(40)); // stays attract-only
+
+        // Total per-coordinate variance as a spread metric.
+        let spread = |setup: &UmapSetup| -> f32 {
+            let emb = setup.optimizer.embedding();
+            let n = emb.nrows() as f32;
+            (0..emb.ncols())
+                .map(|c| {
+                    let col = emb.column(c);
+                    let mean = col.sum() / n;
+                    col.iter().map(|&x| (x - mean) * (x - mean)).sum::<f32>() / n
+                })
+                .sum()
+        };
+        let s_on = spread(&on);
+        let s_off = spread(&off);
+
+        assert!(on.optimizer.embedding().iter().all(|x| x.is_finite()));
+        assert!(
+            s_on > s_off * 1.5,
+            "enabling negative_sample_rate live did not increase spread: on={s_on}, off={s_off}"
+        );
+    }
+
+    #[cfg(feature = "gpu")]
+    #[test]
+    fn test_live_negative_sample_rate_reenables_repulsion_gpu() {
+        // Same regression as the CPU test, on the resident GPU path: a live
+        // negative_sample_rate change must re-seed the GPU `eonns` buffer so
+        // repulsion actually re-arms (it previously kept a stale baseline).
+        let build = || {
+            pollster::block_on(
+                Umap::builder(&make_test_data(300, 10, 21))
+                    .n_neighbors(15)
+                    .n_epochs(200)
+                    .init_method(Init::Random)
+                    .negative_sample_rate(0)
+                    .gpu(true)
+                    .random_state(21)
+                    .setup_async(),
+            )
+            .unwrap()
+        };
+        let mut on = build();
+        let mut off = build();
+
+        pollster::block_on(on.optimizer.step(60));
+        pollster::block_on(off.optimizer.step(60));
+
+        let mut p = on.optimizer.params();
+        p.negative_sample_rate = 5.0;
+        on.optimizer.set_params(p);
+
+        pollster::block_on(on.optimizer.step(80));
+        pollster::block_on(off.optimizer.step(80));
+
+        let spread = |setup: &UmapSetup| -> f32 {
+            let emb = setup.optimizer.embedding();
+            let n = emb.nrows() as f32;
+            (0..emb.ncols())
+                .map(|c| {
+                    let col = emb.column(c);
+                    let mean = col.sum() / n;
+                    col.iter().map(|&x| (x - mean) * (x - mean)).sum::<f32>() / n
+                })
+                .sum()
+        };
+        let s_on = spread(&on);
+        let s_off = spread(&off);
+
+        assert!(on.optimizer.embedding().iter().all(|x| x.is_finite()));
+        assert!(
+            s_on > s_off * 1.5,
+            "GPU: enabling negative_sample_rate live did not increase spread: on={s_on}, off={s_off}"
+        );
+    }
+
+    #[test]
+    fn test_run_to_reaches_horizon() {
+        let data = make_test_data(150, 8, 1);
+        let mut setup = pollster::block_on(
+            Umap::builder(&data)
+                .n_neighbors(10)
+                .n_epochs(50)
+                .init_method(Init::Random)
+                .random_state(1)
+                .setup_async(),
+        )
+        .unwrap();
+
+        let mut logger = Logger::new(false, None, UMAP_STAGES);
+        let n_epochs = setup.n_epochs;
+        pollster::block_on(setup.optimizer.run_to(n_epochs, &mut logger));
+
+        assert_eq!(setup.optimizer.current_epoch() as usize, n_epochs);
+        let emb = setup.optimizer.embedding();
+        assert_eq!(emb.nrows(), 150);
+        assert!(!emb.iter().any(|x| x.is_nan()));
+    }
+
+    #[test]
+    fn test_run_uses_live_learning_rate() {
+        // Regression (#4): run_to anneals from the *live* learning rate, not a
+        // frozen build-time value. With alpha set to 0 via set_params, the decay
+        // starts at 0 and must not move the layout; before the unification run_to
+        // used the frozen initial alpha and would have moved it.
+        let data = make_test_data(150, 8, 5);
+        let mut setup = pollster::block_on(
+            Umap::builder(&data)
+                .n_neighbors(10)
+                .n_epochs(50)
+                .init_method(Init::Random)
+                .random_state(5)
+                .setup_async(),
+        )
+        .unwrap();
+
+        let before = setup.optimizer.embedding().clone();
+
+        let mut p = setup.optimizer.params();
+        p.alpha = 0.0;
+        setup.optimizer.set_params(p);
+
+        let mut logger = Logger::new(false, None, UMAP_STAGES);
+        let n_epochs = setup.n_epochs;
+        pollster::block_on(setup.optimizer.run_to(n_epochs, &mut logger));
+
+        assert_eq!(setup.optimizer.current_epoch() as usize, n_epochs);
+        let after = setup.optimizer.embedding();
+        let max_delta = before
+            .iter()
+            .zip(after.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+        assert!(
+            max_delta < 1e-6,
+            "run_to moved the layout despite learningRate=0 (max delta {max_delta}); \
+             it is not honoring the live learning rate"
+        );
+    }
+
+    #[test]
+    fn test_momentum_build_finite() {
+        let data = make_test_data(150, 8, 3);
+        let result = Umap::builder(&data)
+            .n_neighbors(10)
+            .n_epochs(50)
+            .optimizer(Optimizer::Momentum)
+            .random_state(3)
+            .build()
+            .unwrap();
+
+        assert_eq!(result.embedding.nrows(), 150);
+        assert_eq!(result.embedding.ncols(), 2);
+        assert!(result.embedding.iter().all(|x| x.is_finite()));
+    }
+
+    #[cfg(feature = "gpu")]
+    #[test]
+    fn test_gpu_sgd_bounded() {
+        let data = make_test_data(300, 10, 11);
+        let result = Umap::builder(&data)
+            .n_neighbors(15)
+            .n_epochs(200)
+            .gpu(true)
+            .init_method(Init::Random)
+            .random_state(11)
+            .build()
+            .unwrap();
+
+        assert!(result.embedding.iter().all(|x| x.is_finite()));
+        let max_abs = result.embedding.iter().fold(0.0f32, |m, &x| m.max(x.abs()));
+        assert!(
+            max_abs < 1000.0,
+            "GPU SGD max|coord| = {} (unbounded?)",
+            max_abs
+        );
+    }
+
+    #[cfg(feature = "gpu")]
+    #[test]
+    fn test_gpu_momentum_finite() {
+        let data = make_test_data(300, 10, 13);
+        let result = Umap::builder(&data)
+            .n_neighbors(15)
+            .n_epochs(200)
+            .gpu(true)
+            .optimizer(Optimizer::Momentum)
+            .random_state(13)
+            .build()
+            .unwrap();
+
+        assert!(result.embedding.iter().all(|x| x.is_finite()));
+    }
+
+    #[cfg(feature = "gpu")]
+    #[test]
+    fn test_gpu_momentum_step_bounded() {
+        // Smoke test for the GPU momentum step() path (flat learning rate, no
+        // decay) — previously uncovered; the existing momentum GPU test uses
+        // build()/run_to, which decays alpha. The apply shader clamps the summed
+        // per-epoch gradient to ±grad_clamp on the momentum path (as it does for
+        // SGD) before integrating it into the velocity, bounding the step.
+        let data = make_test_data(300, 10, 17);
+        let mut setup = pollster::block_on(
+            Umap::builder(&data)
+                .n_neighbors(15)
+                .n_epochs(200)
+                .optimizer(Optimizer::Momentum)
+                .gpu(true)
+                .init_method(Init::Random)
+                .random_state(17)
+                .setup_async(),
+        )
+        .unwrap();
+
+        pollster::block_on(setup.optimizer.step(200));
+
+        let emb = setup.optimizer.embedding();
+        assert!(emb.iter().all(|x| x.is_finite()));
+        let max_abs = emb.iter().fold(0.0f32, |m, &x| m.max(x.abs()));
+        assert!(
+            max_abs < 1000.0,
+            "GPU momentum step() max|coord| = {max_abs} (unbounded?)"
+        );
     }
 }

--- a/packages/umap/umap/src/optimize.rs
+++ b/packages/umap/umap/src/optimize.rs
@@ -3,6 +3,39 @@ use nndescent::rng::TauRng;
 use nndescent::Logger;
 use rayon::prelude::*;
 
+/// Which optimizer to use for the layout SGD.
+///
+/// Both share one β-parameterized velocity-SGD kernel: `Sgd` uses β=0 (the
+/// reference UMAP update, no velocity buffer), `Momentum` uses β=[`MOMENTUM_BETA`]
+/// and a persistent velocity buffer (better global structure).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Optimizer {
+    /// Reference-faithful incremental SGD (β=0). Default.
+    Sgd,
+    /// Velocity-SGD with classical momentum (β=[`MOMENTUM_BETA`]).
+    Momentum,
+}
+
+/// Fixed momentum coefficient (classical, not Nesterov). Not exposed live — it
+/// couples with the learning rate and blows up the layout scale as β→1.
+pub(crate) const MOMENTUM_BETA: f32 = 0.9;
+
+/// Live-tunable optimizer parameters. These can be changed between steps without
+/// rebuilding the optimizer (the caller controls learning-rate decay).
+#[derive(Clone, Copy, Debug)]
+pub struct LiveParams {
+    /// Learning rate (no decay applied here — see [`UmapOptimizer::run_to`]).
+    pub alpha: f32,
+    /// Repulsion strength (γ).
+    pub gamma: f32,
+    /// Number of negative samples per positive sample.
+    pub negative_sample_rate: f32,
+    /// Output-distance curve parameter `a` (from `find_ab_params`).
+    pub a: f32,
+    /// Output-distance curve parameter `b` (from `find_ab_params`).
+    pub b: f32,
+}
+
 /// Clamp gradient to [-4.0, 4.0] to prevent instability.
 #[inline]
 fn clip(val: f32) -> f32 {
@@ -21,166 +54,559 @@ fn rdist(x: &[f32], y: &[f32]) -> f32 {
         .sum()
 }
 
-/// Optimize the low-dimensional embedding using SGD with Hogwild parallelism.
+/// Collect the edges that are due to be sampled at `current_epoch`, advancing the
+/// per-edge sampling schedule counters in place.
 ///
-/// Minimizes the fuzzy set cross entropy between the high-dimensional
-/// fuzzy simplicial set and the low-dimensional one, using negative
-/// sampling similar to word2vec.
+/// Returns `(edge_index, n_negative_samples)` for each active edge.
 ///
-/// The edge gradient updates are parallelized using the Hogwild approach
-/// (Recht et al. 2011): concurrent writes to the embedding array are
-/// allowed without synchronization. With dim=2, each update touches only
-/// 2 floats per vertex, so conflicts are rare and benign.
-pub fn optimize_layout_euclidean(
-    embedding: &mut Array2<f32>,
-    head: &[usize],
-    tail: &[usize],
-    epochs_per_sample: &[f32],
-    n_epochs: usize,
-    n_vertices: usize,
-    a: f64,
-    b: f64,
-    gamma: f32,
-    initial_alpha: f32,
+/// `epochs_per_negative_sample` is computed **inline** as
+/// `epochs_per_sample[i] / negative_sample_rate`, so changing the rate live needs
+/// no rebuild of any precomputed table.
+pub(crate) fn collect_active_edges(
+    epochs_per_sample: &[f64],
+    epoch_of_next_sample: &mut [f64],
+    epoch_of_next_negative_sample: &mut [f64],
+    current_epoch: u64,
     negative_sample_rate: f32,
-    rng_state: [i64; 3],
-    logger: &mut Logger,
-) {
-    let dim = embedding.ncols();
-    let n_edges = head.len();
+) -> Vec<(usize, usize)> {
+    let n_edges = epochs_per_sample.len();
+    let cur = current_epoch as f64;
+    let rate = negative_sample_rate as f64;
 
-    let epochs_per_negative_sample: Vec<f32> = epochs_per_sample
-        .iter()
-        .map(|&e| e / negative_sample_rate)
-        .collect();
-    let mut epoch_of_next_sample = epochs_per_sample.to_vec();
-    let mut epoch_of_next_negative_sample = epochs_per_negative_sample.clone();
-
-    let a = a as f32;
-    let b = b as f32;
-
-    // Use flat slice for embedding data. ndarray Array2 is row-major,
-    // so row j starts at offset j*dim.
-    let emb = embedding
-        .as_slice_memory_order_mut()
-        .expect("embedding not contiguous");
-
-    // SAFETY: Hogwild-style parallel SGD (Recht et al., 2011). The embedding array
-    // is shared mutably across threads WITHOUT synchronization. This is intentional:
-    // - Each gradient update touches only `dim` floats (typically 2-4) per vertex.
-    // - Concurrent writes to the same vertex produce slightly stale/torn reads, which
-    //   act as additional stochastic noise and do not affect convergence in practice.
-    // - This matches the approach used by the reference Python UMAP (via numba prange)
-    //   and is standard practice for embedding optimization.
-    //
-    // Formally, creating multiple `&mut` slices to overlapping memory is UB under Rust's
-    // aliasing model. In practice, the generated code is safe because:
-    // (a) all accesses are simple f32 loads/stores (no LLVM optimizations rely on
-    //     noalias for correctness at this granularity), and
-    // (b) the primary target is WASM, which is single-threaded (no actual concurrency).
-    //
-    // For a strictly sound alternative, raw pointer arithmetic or AtomicF32 could be
-    // used, at the cost of readability and (for atomics) performance.
-    let emb_ptr = emb.as_mut_ptr() as usize;
-
-    for epoch in 0..n_epochs {
-        let alpha = initial_alpha * (1.0 - epoch as f32 / n_epochs as f32);
-
-        // Phase 1: Sequentially collect active edges and advance scheduling counters.
-        // Each active edge records (edge_index, n_negative_samples).
-        let mut active_edges: Vec<(usize, usize)> = Vec::new();
-        for i in 0..n_edges {
-            if epoch_of_next_sample[i] > epoch as f32 {
-                continue;
-            }
-
-            let n_neg = ((epoch as f32 - epoch_of_next_negative_sample[i])
-                / epochs_per_negative_sample[i]) as usize;
-
-            active_edges.push((i, n_neg));
-
-            epoch_of_next_sample[i] += epochs_per_sample[i];
-            epoch_of_next_negative_sample[i] += n_neg as f32 * epochs_per_negative_sample[i];
+    let mut active_edges: Vec<(usize, usize)> = Vec::new();
+    for i in 0..n_edges {
+        if epoch_of_next_sample[i] > cur {
+            continue;
         }
 
-        // Phase 2: Apply gradients in parallel (Hogwild).
-        // Each edge gets its own RNG seeded deterministically from
-        // (rng_state, edge_index, epoch) — no shared mutable RNG state.
-        active_edges.par_iter().for_each_init(
-            || (vec![0.0f32; dim], vec![0.0f32; dim], vec![0.0f32; dim]),
-            |(current, other, neg_other), &(edge_idx, n_neg)| {
-                // SAFETY: see Hogwild comment above on emb_ptr.
-                let emb = unsafe {
-                    std::slice::from_raw_parts_mut(emb_ptr as *mut f32, n_vertices * dim)
-                };
+        // Negative-sample count for this edge this epoch. When the rate is 0 we
+        // simply do no repulsion (and don't advance the negative counter, which
+        // would otherwise divide by an infinite interval).
+        let n_neg = if rate > 0.0 {
+            let epn = epochs_per_sample[i] / rate;
+            let n = ((cur - epoch_of_next_negative_sample[i]) / epn) as usize;
+            epoch_of_next_negative_sample[i] += n as f64 * epn;
+            n
+        } else {
+            0
+        };
 
-                let j = head[edge_idx];
-                let k = tail[edge_idx];
-                let j_off = j * dim;
-                let k_off = k * dim;
+        active_edges.push((i, n_neg));
+        epoch_of_next_sample[i] += epochs_per_sample[i];
+    }
 
-                // Copy current positions to local buffers
+    active_edges
+}
+
+/// Run one epoch of Hogwild velocity-SGD in place.
+///
+/// `beta == 0.0` ⇒ plain SGD (the reference UMAP update; `velocity` is unused and
+/// may be empty). `beta > 0.0` ⇒ classical momentum using `velocity`
+/// (`len == n_vertices * dim`).
+///
+/// The gradient math (attractive `-2ab·d^{2b}/d² / (a·d^{2b}+1)`, repulsive
+/// `2γb/((0.001+d²)(a·d^{2b}+1))`, per-edge clip to ±4) is identical to the
+/// reference implementation. **Sign convention:** `g` is the SGD *position delta*
+/// (`x += α·g`); velocity-SGD is `v = β·v + g; x += α·v`, so `β=0` reduces to
+/// `x += α·g` exactly — no negation anywhere.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn run_one_epoch_hogwild(
+    emb: &mut [f32],
+    velocity: &mut [f32],
+    dim: usize,
+    n_vertices: usize,
+    head: &[usize],
+    tail: &[usize],
+    epochs_per_sample: &[f64],
+    epoch_of_next_sample: &mut [f64],
+    epoch_of_next_negative_sample: &mut [f64],
+    current_epoch: u64,
+    params: LiveParams,
+    beta: f32,
+    rng_state: [i64; 3],
+) {
+    // Phase 1: sequentially collect active edges and advance scheduling counters.
+    let active_edges = collect_active_edges(
+        epochs_per_sample,
+        epoch_of_next_sample,
+        epoch_of_next_negative_sample,
+        current_epoch,
+        params.negative_sample_rate,
+    );
+
+    let alpha = params.alpha;
+    let gamma = params.gamma;
+    let a = params.a;
+    let b = params.b;
+    let epoch = current_epoch;
+    let use_momentum = beta > 0.0;
+
+    // SAFETY: Hogwild-style parallel SGD (Recht et al., 2011). The embedding array
+    // (and, for momentum, the velocity array) is shared mutably across threads
+    // WITHOUT synchronization. This is intentional:
+    // - Each gradient update touches only `dim` floats (typically 2-4) per vertex.
+    // - Concurrent writes to the same vertex produce slightly stale/torn reads,
+    //   which act as additional stochastic noise and do not affect convergence in
+    //   practice. The velocity buffer is touched only at the same (vertex,
+    //   component) slots as the embedding, so it races identically and benignly;
+    //   `clip` bounds `g` and α decays, so β·v cannot amplify the divergence.
+    // - This matches reference Python UMAP (numba prange) and is standard practice.
+    //
+    // Formally, multiple `&mut` slices to overlapping memory is UB under Rust's
+    // aliasing model; in practice the generated code is safe because all accesses
+    // are simple f32 loads/stores, and the primary target is single-threaded WASM.
+    let emb_ptr = emb.as_mut_ptr() as usize;
+    let vel_ptr = if use_momentum {
+        velocity.as_mut_ptr() as usize
+    } else {
+        0
+    };
+
+    // Phase 2: apply gradients in parallel (Hogwild). Each edge gets its own RNG
+    // seeded deterministically from (rng_state, edge_index, epoch).
+    active_edges.par_iter().for_each_init(
+        || (vec![0.0f32; dim], vec![0.0f32; dim], vec![0.0f32; dim]),
+        |(current, other, neg_other), &(edge_idx, n_neg)| {
+            // SAFETY: see Hogwild comment above on emb_ptr / vel_ptr.
+            let emb =
+                unsafe { std::slice::from_raw_parts_mut(emb_ptr as *mut f32, n_vertices * dim) };
+            let vel: &mut [f32] = if use_momentum {
+                unsafe { std::slice::from_raw_parts_mut(vel_ptr as *mut f32, n_vertices * dim) }
+            } else {
+                &mut []
+            };
+
+            let j = head[edge_idx];
+            let k = tail[edge_idx];
+            let j_off = j * dim;
+            let k_off = k * dim;
+
+            current.copy_from_slice(&emb[j_off..j_off + dim]);
+            other.copy_from_slice(&emb[k_off..k_off + dim]);
+            let dist_squared = rdist(current, other);
+
+            // Positive sample: attractive force.
+            let grad_coeff = if dist_squared > 0.0 {
+                let pow_b = dist_squared.powf(b);
+                -2.0 * a * b * (pow_b / dist_squared) / (a * pow_b + 1.0)
+            } else {
+                0.0
+            };
+
+            for d in 0..dim {
+                let g = clip(grad_coeff * (current[d] - other[d]));
+                if use_momentum {
+                    let vj = beta * vel[j_off + d] + g;
+                    vel[j_off + d] = vj;
+                    emb[j_off + d] += alpha * vj;
+                    let vk = beta * vel[k_off + d] - g;
+                    vel[k_off + d] = vk;
+                    emb[k_off + d] += alpha * vk;
+                } else {
+                    emb[j_off + d] += alpha * g;
+                    emb[k_off + d] -= alpha * g;
+                }
+            }
+
+            // Negative samples: repulsive force (j only).
+            let mut rng = TauRng::from_state([
+                rng_state[0]
+                    .wrapping_add(edge_idx as i64)
+                    .wrapping_mul(epoch as i64 + 1),
+                rng_state[1].wrapping_add(j as i64),
+                rng_state[2].wrapping_add(edge_idx as i64),
+            ]);
+
+            for _ in 0..n_neg {
+                let neg_k = (rng.tau_rand_int().unsigned_abs() as usize) % n_vertices;
+                let neg_off = neg_k * dim;
+                neg_other.copy_from_slice(&emb[neg_off..neg_off + dim]);
+                // Re-read current since it may have been updated.
                 current.copy_from_slice(&emb[j_off..j_off + dim]);
-                other.copy_from_slice(&emb[k_off..k_off + dim]);
-                let dist_squared = rdist(current, other);
+                let dist_squared = rdist(current, neg_other);
 
-                // Positive sample: attractive force
                 let grad_coeff = if dist_squared > 0.0 {
-                    let pow_b = dist_squared.powf(b);
-                    -2.0 * a * b * (pow_b / dist_squared) / (a * pow_b + 1.0)
+                    2.0 * gamma * b / ((0.001 + dist_squared) * (a * dist_squared.powf(b) + 1.0))
+                } else if j == neg_k {
+                    continue;
                 } else {
                     0.0
                 };
 
                 for d in 0..dim {
-                    let grad = clip(grad_coeff * (current[d] - other[d]));
-                    emb[j_off + d] += alpha * grad;
-                    emb[k_off + d] -= alpha * grad;
-                }
-
-                // Negative samples: repulsive force
-                // Per-edge RNG seeded from (rng_state, edge_index, epoch)
-                let mut rng = TauRng::from_state([
-                    rng_state[0]
-                        .wrapping_add(edge_idx as i64)
-                        .wrapping_mul(epoch as i64 + 1),
-                    rng_state[1].wrapping_add(j as i64),
-                    rng_state[2].wrapping_add(edge_idx as i64),
-                ]);
-
-                for _ in 0..n_neg {
-                    let neg_k = (rng.tau_rand_int().unsigned_abs() as usize) % n_vertices;
-
-                    let neg_off = neg_k * dim;
-                    neg_other.copy_from_slice(&emb[neg_off..neg_off + dim]);
-                    // Re-read current since it may have been updated
-                    current.copy_from_slice(&emb[j_off..j_off + dim]);
-                    let dist_squared = rdist(current, neg_other);
-
-                    let grad_coeff = if dist_squared > 0.0 {
-                        2.0 * gamma * b
-                            / ((0.001 + dist_squared) * (a * dist_squared.powf(b) + 1.0))
-                    } else if j == neg_k {
-                        continue;
+                    let g = if grad_coeff > 0.0 {
+                        clip(grad_coeff * (current[d] - neg_other[d]))
                     } else {
                         0.0
                     };
-
-                    for d in 0..dim {
-                        let grad = if grad_coeff > 0.0 {
-                            clip(grad_coeff * (current[d] - neg_other[d]))
-                        } else {
-                            0.0
-                        };
-                        emb[j_off + d] += alpha * grad;
+                    if use_momentum {
+                        let vj = beta * vel[j_off + d] + g;
+                        vel[j_off + d] = vj;
+                        emb[j_off + d] += alpha * vj;
+                    } else {
+                        emb[j_off + d] += alpha * g;
                     }
                 }
-            },
+            }
+        },
+    );
+}
+
+/// A resumable UMAP layout optimizer.
+///
+/// Advances the SGD layout `k` epochs at a time ([`step`](Self::step)), or runs
+/// to a fixed horizon with learning-rate decay ([`run_to`](Self::run_to), which
+/// reproduces standard run-to-completion UMAP). Parameters and the optimizer can
+/// be changed live between steps, and the embedding can be re-initialized
+/// ([`reinit_embedding`](Self::reinit_embedding)) to restart from a new layout.
+///
+/// On GPU, the resident buffers live in the optimizer; `step`/`run_to` download
+/// the embedding into the CPU `embedding` mirror once at the end, and all getters
+/// read that mirror.
+pub struct UmapOptimizer {
+    embedding: Array2<f32>,
+    n_vertices: usize,
+    dim: usize,
+    head: Vec<usize>,
+    tail: Vec<usize>,
+    epochs_per_sample: Vec<f64>,
+    epoch_of_next_sample: Vec<f64>,
+    epoch_of_next_negative_sample: Vec<f64>,
+    current_epoch: u64,
+    params: LiveParams,
+    optimizer: Optimizer,
+    rng_state: [i64; 3],
+    /// Velocity buffer for Momentum; empty for Sgd (no overhead).
+    velocity: Vec<f32>,
+    #[cfg(feature = "gpu")]
+    gpu: Option<crate::gpu_optimize::OptimizeGpuContext>,
+    /// f32-counter coordinate for the GPU schedule; reset to 0 on rebase.
+    #[cfg(feature = "gpu")]
+    gpu_epoch: u32,
+}
+
+impl UmapOptimizer {
+    /// Create a CPU optimizer over the given edge list and initial embedding.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        head: Vec<usize>,
+        tail: Vec<usize>,
+        epochs_per_sample: &[f32],
+        embedding: Array2<f32>,
+        params: LiveParams,
+        optimizer: Optimizer,
+        rng_state: [i64; 3],
+    ) -> Self {
+        let n_vertices = embedding.nrows();
+        let dim = embedding.ncols();
+
+        let eps: Vec<f64> = epochs_per_sample.iter().map(|&e| e as f64).collect();
+        let epoch_of_next_sample = eps.clone();
+        let rate = params.negative_sample_rate as f64;
+        let epoch_of_next_negative_sample: Vec<f64> = eps
+            .iter()
+            .map(|&e| if rate > 0.0 { e / rate } else { f64::INFINITY })
+            .collect();
+
+        let velocity = match optimizer {
+            Optimizer::Momentum => vec![0.0f32; n_vertices * dim],
+            Optimizer::Sgd => Vec::new(),
+        };
+
+        UmapOptimizer {
+            embedding,
+            n_vertices,
+            dim,
+            head,
+            tail,
+            epochs_per_sample: eps,
+            epoch_of_next_sample,
+            epoch_of_next_negative_sample,
+            current_epoch: 0,
+            params,
+            optimizer,
+            rng_state,
+            velocity,
+            #[cfg(feature = "gpu")]
+            gpu: None,
+            #[cfg(feature = "gpu")]
+            gpu_epoch: 0,
+        }
+    }
+
+    /// Create a GPU-backed optimizer. Falls back to the CPU path (no resident GPU
+    /// context) if no suitable adapter is available.
+    #[cfg(feature = "gpu")]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn new_gpu(
+        head: Vec<usize>,
+        tail: Vec<usize>,
+        epochs_per_sample: &[f32],
+        embedding: Array2<f32>,
+        params: LiveParams,
+        optimizer: Optimizer,
+        rng_state: [i64; 3],
+        n_neighbors: usize,
+    ) -> Self {
+        let mut opt = Self::new(
+            head,
+            tail,
+            epochs_per_sample,
+            embedding,
+            params,
+            optimizer,
+            rng_state,
         );
 
-        if n_epochs >= 10 && epoch % (n_epochs / 10) == 0 {
+        // Owned, GPU-friendly copies so no borrow of `opt` is held across the await.
+        let emb_vec: Vec<f32> = opt.embedding.as_slice().expect("contiguous").to_vec();
+        let eps_f32: Vec<f32> = opt.epochs_per_sample.iter().map(|&e| e as f32).collect();
+        let head_u32: Vec<u32> = opt.head.iter().map(|&h| h as u32).collect();
+        let tail_u32: Vec<u32> = opt.tail.iter().map(|&t| t as u32).collect();
+
+        opt.gpu = crate::gpu_optimize::OptimizeGpuContext::new(
+            &emb_vec,
+            &head_u32,
+            &tail_u32,
+            &eps_f32,
+            opt.n_vertices as u32,
+            opt.dim as u32,
+            n_neighbors,
+            params.negative_sample_rate,
+            rng_state,
+        )
+        .await;
+
+        opt
+    }
+
+    #[inline]
+    fn beta(&self) -> f32 {
+        match self.optimizer {
+            Optimizer::Sgd => 0.0,
+            Optimizer::Momentum => MOMENTUM_BETA,
+        }
+    }
+
+    /// Run one CPU epoch in place at the current parameters.
+    fn run_cpu_epoch(&mut self, params: LiveParams, beta: f32) {
+        let emb = self
+            .embedding
+            .as_slice_memory_order_mut()
+            .expect("embedding not contiguous");
+        run_one_epoch_hogwild(
+            emb,
+            &mut self.velocity,
+            self.dim,
+            self.n_vertices,
+            &self.head,
+            &self.tail,
+            &self.epochs_per_sample,
+            &mut self.epoch_of_next_sample,
+            &mut self.epoch_of_next_negative_sample,
+            self.current_epoch,
+            params,
+            beta,
+            self.rng_state,
+        );
+    }
+
+    /// Advance the layout by `n_epochs` at the current learning rate (no decay).
+    /// Intended for interactive/real-time stepping.
+    pub async fn step(&mut self, n_epochs: usize) {
+        let beta = self.beta();
+
+        #[cfg(feature = "gpu")]
+        if self.gpu.is_some() {
+            for _ in 0..n_epochs {
+                self.gpu.as_ref().unwrap().run_epoch(
+                    self.gpu_epoch,
+                    self.params,
+                    beta,
+                    self.optimizer,
+                );
+                self.current_epoch += 1;
+                self.gpu_epoch += 1;
+                if self.gpu_epoch >= (1u32 << 18) {
+                    self.gpu.as_ref().unwrap().rebase(self.gpu_epoch);
+                    self.gpu_epoch = 0;
+                }
+            }
+            self.download_from_gpu().await;
+            return;
+        }
+
+        for _ in 0..n_epochs {
+            self.run_cpu_epoch(self.params, beta);
+            self.current_epoch += 1;
+        }
+    }
+
+    /// Run to a fixed horizon with linear learning-rate decay, mirroring standard
+    /// run-to-completion UMAP. A fresh optimizer started at epoch 0 reproduces the
+    /// reference layout (modulo the f64 schedule counters).
+    ///
+    /// The decay peak is the live learning rate (`self.params.alpha` — the
+    /// configured rate, or whatever [`set_params`](Self::set_params) last set).
+    /// Decay is applied to a local copy of the parameters; `self.params` is left
+    /// untouched so a subsequent [`step`](Self::step) continues at that same
+    /// learning rate rather than at the decayed-to-zero value.
+    pub async fn run_to(&mut self, n_epochs: usize, logger: &mut Logger) {
+        let beta = self.beta();
+        let initial_alpha = self.params.alpha;
+
+        #[cfg(feature = "gpu")]
+        if self.gpu.is_some() {
+            while self.current_epoch < n_epochs as u64 {
+                let epoch = self.current_epoch;
+                let mut p = self.params;
+                p.alpha = (initial_alpha * (1.0 - epoch as f32 / n_epochs as f32)).max(0.0);
+                self.gpu
+                    .as_ref()
+                    .unwrap()
+                    .run_epoch(self.gpu_epoch, p, beta, self.optimizer);
+                self.current_epoch += 1;
+                self.gpu_epoch += 1;
+                if self.gpu_epoch >= (1u32 << 18) {
+                    self.gpu.as_ref().unwrap().rebase(self.gpu_epoch);
+                    self.gpu_epoch = 0;
+                }
+                Self::log_progress(logger, epoch, n_epochs);
+            }
+            self.download_from_gpu().await;
+            return;
+        }
+
+        while self.current_epoch < n_epochs as u64 {
+            let epoch = self.current_epoch;
+            let mut p = self.params;
+            p.alpha = (initial_alpha * (1.0 - epoch as f32 / n_epochs as f32)).max(0.0);
+            self.run_cpu_epoch(p, beta);
+            self.current_epoch += 1;
+            Self::log_progress(logger, epoch, n_epochs);
+        }
+    }
+
+    fn log_progress(logger: &mut Logger, epoch: u64, n_epochs: usize) {
+        if n_epochs >= 10 && (epoch as usize) % (n_epochs / 10) == 0 {
             logger.log(&format!("completed {} / {} epochs", epoch, n_epochs));
         }
         logger.stage_progress((epoch + 1) as f64 / n_epochs as f64, None);
+    }
+
+    #[cfg(feature = "gpu")]
+    async fn download_from_gpu(&mut self) {
+        let result = self.gpu.as_ref().unwrap().download_embedding().await;
+        self.embedding
+            .as_slice_memory_order_mut()
+            .expect("embedding not contiguous")
+            .copy_from_slice(&result);
+    }
+
+    /// (Re)seed the per-edge negative-sample counters for the current rate so the
+    /// next negative sample for each edge falls ~`epn` epochs after `from_epoch`.
+    ///
+    /// At `from_epoch == 0` this reproduces the construction baseline (`e / rate`).
+    /// Keeping the rate fully live requires calling this on any rate change: the
+    /// counter is rate-dependent, so a stale baseline (or the `+inf` park used when
+    /// the rate is 0) would otherwise leave repulsion mis-scheduled — or, for a
+    /// 0 → positive change, permanently disabled.
+    fn reseed_negative_schedule(&mut self, from_epoch: f64) {
+        let rate = self.params.negative_sample_rate as f64;
+        for (i, &e) in self.epochs_per_sample.iter().enumerate() {
+            self.epoch_of_next_negative_sample[i] = if rate > 0.0 {
+                from_epoch + e / rate
+            } else {
+                f64::INFINITY
+            };
+        }
+    }
+
+    /// Update the live parameters (learning rate, repulsion, negative-sample rate,
+    /// and the a/b curve parameters).
+    ///
+    /// Changing `negative_sample_rate` re-seeds the negative-sample schedule
+    /// relative to the current epoch, so the new rate takes effect cleanly from
+    /// here on (no stale baseline, and a 0 → positive change re-arms repulsion).
+    pub fn set_params(&mut self, params: LiveParams) {
+        let rate_changed = params.negative_sample_rate != self.params.negative_sample_rate;
+        self.params = params;
+        if rate_changed {
+            let from = self.current_epoch as f64;
+            self.reseed_negative_schedule(from);
+            #[cfg(feature = "gpu")]
+            if let Some(gpu) = &self.gpu {
+                gpu.reseed_negative_schedule(params.negative_sample_rate, self.gpu_epoch);
+            }
+        }
+    }
+
+    /// Switch optimizer. Resets the velocity (zeroed for Momentum, freed for Sgd).
+    pub fn set_optimizer(&mut self, optimizer: Optimizer) {
+        self.optimizer = optimizer;
+        match optimizer {
+            Optimizer::Momentum => {
+                if self.velocity.len() == self.n_vertices * self.dim {
+                    self.velocity.iter_mut().for_each(|v| *v = 0.0);
+                } else {
+                    self.velocity = vec![0.0f32; self.n_vertices * self.dim];
+                }
+            }
+            Optimizer::Sgd => self.velocity = Vec::new(),
+        }
+        #[cfg(feature = "gpu")]
+        if let Some(gpu) = &self.gpu {
+            gpu.zero_velocity();
+        }
+    }
+
+    /// Replace the embedding and reset the schedule, epoch, and velocity — i.e. a
+    /// full restart of the layout optimization from a new initial position.
+    pub fn reinit_embedding(&mut self, embedding: Array2<f32>) {
+        assert_eq!(embedding.nrows(), self.n_vertices);
+        assert_eq!(embedding.ncols(), self.dim);
+        self.embedding = embedding;
+
+        self.epoch_of_next_sample
+            .copy_from_slice(&self.epochs_per_sample);
+        self.reseed_negative_schedule(0.0);
+        self.current_epoch = 0;
+        self.velocity.iter_mut().for_each(|v| *v = 0.0);
+
+        #[cfg(feature = "gpu")]
+        if let Some(gpu) = &self.gpu {
+            let emb_vec: Vec<f32> = self.embedding.as_slice().expect("contiguous").to_vec();
+            gpu.reupload_embedding(&emb_vec);
+            gpu.reset_schedule(self.params.negative_sample_rate);
+            gpu.zero_velocity();
+            self.gpu_epoch = 0;
+        }
+    }
+
+    /// The current live parameters.
+    pub fn params(&self) -> LiveParams {
+        self.params
+    }
+
+    /// The current embedding (CPU mirror; valid after `step`/`run_to`).
+    pub fn embedding(&self) -> &Array2<f32> {
+        &self.embedding
+    }
+
+    /// Consume the optimizer and return the embedding.
+    pub fn into_embedding(self) -> Array2<f32> {
+        self.embedding
+    }
+
+    /// Copy the current embedding into `out` (synchronous memcpy from the mirror).
+    pub fn copy_embedding_into(&self, out: &mut [f32]) {
+        let src = self.embedding.as_slice().expect("embedding not contiguous");
+        let n = out.len().min(src.len());
+        out[..n].copy_from_slice(&src[..n]);
+    }
+
+    /// The number of epochs run so far.
+    pub fn current_epoch(&self) -> u64 {
+        self.current_epoch
     }
 }

--- a/packages/umap/umap/src/shaders/optimize.wgsl
+++ b/packages/umap/umap/src/shaders/optimize.wgsl
@@ -1,37 +1,52 @@
-// UMAP SGD optimization kernel with atomic gradient accumulation.
+// UMAP velocity-SGD optimization kernel with atomic gradient accumulation.
 //
-// Two-pass approach:
-//   1. accumulate_grads: each thread processes one edge, computing attractive
-//      and repulsive gradients, accumulating them via atomicAdd into a
-//      fixed-point i32 buffer. This avoids lost updates from GPU write conflicts.
-//   2. apply_grads: each thread reads accumulated gradient for one embedding
-//      element, converts from fixed-point, applies with learning rate alpha,
-//      and clears the accumulator.
+// Resident, self-scheduling design: the edge list and per-edge sampling schedule
+// counters live in GPU buffers across the whole run. Three entry points:
+//
+//   1. accumulate_grads: one thread per edge. Each edge reads its own schedule
+//      counters, decides if it is due this epoch, advances its own counters (it
+//      is the sole writer of slot `i`, so no atomics on counters are needed),
+//      then atomicAdds its attractive + repulsive gradients into a fixed-point
+//      i32 buffer (avoids lost updates from GPU write conflicts). A sub-batch
+//      processes edges in [edge_offset, edge_end).
+//   2. apply_grads: one thread per embedding element. Reads + clears the
+//      accumulated gradient (clamped to ±grad_clamp). SGD applies it directly;
+//      Momentum integrates it into a velocity buffer.
+//   3. rebase_schedule: subtract a baseline from both counter buffers so the f32
+//      counters stay precise over indefinitely long runs.
 
 struct OptimizeParams {
     n_vertices: u32,
     dim: u32,
     n_edges: u32,
-    _pad0: u32,
+    epoch: u32,
     a: f32,
     b: f32,
     gamma: f32,
     alpha: f32,
     grad_clamp: f32,
+    negative_sample_rate: f32,
+    base_seed: u32,
     apply_offset: u32,
-    _pad2: f32,
-    _pad3: f32,
+    edge_offset: u32,
+    edge_end: u32,
+    optimizer: u32,
+    beta: f32,
 }
 
 @group(0) @binding(0) var<storage, read_write> embedding: array<f32>;
-@group(0) @binding(1) var<storage, read> edges: array<u32>;
-@group(0) @binding(2) var<uniform> params: OptimizeParams;
-@group(0) @binding(3) var<storage, read_write> grad_accum: array<atomic<i32>>;
+@group(0) @binding(1) var<storage, read> head: array<u32>;
+@group(0) @binding(2) var<storage, read> tail: array<u32>;
+@group(0) @binding(3) var<storage, read> eps: array<f32>;
+@group(0) @binding(4) var<storage, read_write> eons: array<f32>;
+@group(0) @binding(5) var<storage, read_write> eonns: array<f32>;
+@group(0) @binding(6) var<storage, read_write> grad_accum: array<atomic<i32>>;
+@group(0) @binding(7) var<storage, read_write> velocity: array<f32>;
+@group(0) @binding(8) var<uniform> params: OptimizeParams;
 
-// Fixed-point scale for atomic gradient accumulation.
-// Per-edge gradients are clamped to [-4, 4]. Max contributions per vertex
-// per epoch ≈ 7*K (K=n_neighbors). Worst case (K=100, all max):
-// 700 * 4 * 65536 = 183M, well within i32 ±2.1B.
+// Fixed-point scale for atomic gradient accumulation. Per-edge gradients are
+// clamped to [-4, 4]; max contributions per vertex per epoch ≈ 7*K, so worst
+// case (K=100): 700 * 4 * 65536 = 183M, well within i32 ±2.1B.
 const FIXED_SCALE: f32 = 65536.0;
 // Per-edge gradient clamp, matching the CPU implementation.
 const EDGE_CLAMP: f32 = 4.0;
@@ -50,29 +65,42 @@ fn pcg_hash(input: u32) -> u32 {
     return (word >> 22u) ^ word;
 }
 
-// Pass 1: Accumulate gradients for one edge into grad_accum using atomicAdd.
+// Pass 1: self-schedule, then accumulate this edge's gradients via atomicAdd.
 @compute @workgroup_size(256)
 fn accumulate_grads(@builtin(global_invocation_id) gid: vec3<u32>) {
-    let idx = gid.x;
-    if (idx >= params.n_edges) {
+    let i = params.edge_offset + gid.x;
+    if (i >= params.edge_end) {
         return;
     }
 
-    let j = edges[idx * 4u];
-    let k = edges[idx * 4u + 1u];
-    let n_neg = edges[idx * 4u + 2u];
-    let rng_seed = edges[idx * 4u + 3u];
+    let epoch_f = f32(params.epoch);
+    if (eons[i] > epoch_f) {
+        return; // not due to be sampled this epoch
+    }
+
+    // Self-schedule: advance own counters (sole owner of slot i, no atomics).
+    var n_neg = 0u;
+    if (params.negative_sample_rate > 0.0) {
+        let epn = eps[i] / params.negative_sample_rate;
+        let raw = (epoch_f - eonns[i]) / epn;
+        if (raw > 0.0) {
+            n_neg = u32(raw);
+        }
+        eonns[i] = eonns[i] + f32(n_neg) * epn;
+    }
+    eons[i] = eons[i] + eps[i];
+
+    let j = head[i];
+    let k = tail[i];
     let j_off = j * params.dim;
     let k_off = k * params.dim;
 
-    // Compute squared distance between j and k
+    // Attractive force (positive sample).
     var dist_sq: f32 = 0.0;
     for (var d = 0u; d < params.dim; d++) {
         let diff = embedding[j_off + d] - embedding[k_off + d];
         dist_sq += diff * diff;
     }
-
-    // Attractive force (positive sample)
     if (dist_sq > 0.0) {
         let pow_b = pow(dist_sq, params.b);
         let grad_coeff = -2.0 * params.a * params.b * (pow_b / dist_sq) / (params.a * pow_b + 1.0);
@@ -84,9 +112,11 @@ fn accumulate_grads(@builtin(global_invocation_id) gid: vec3<u32>) {
         }
     }
 
-    // Repulsive forces (negative sampling)
+    // Repulsive forces (negative sampling). Per-edge RNG seed is deterministic
+    // from (base_seed, epoch, edge index).
+    let seed = params.base_seed * (params.epoch + 1u) + i * 2654435761u;
     for (var neg_i = 0u; neg_i < n_neg; neg_i++) {
-        let neg_k = pcg_hash(rng_seed ^ (neg_i + 1u)) % params.n_vertices;
+        let neg_k = pcg_hash(seed ^ (neg_i + 1u)) % params.n_vertices;
         if (neg_k == j) {
             continue;
         }
@@ -111,15 +141,15 @@ fn accumulate_grads(@builtin(global_invocation_id) gid: vec3<u32>) {
     }
 }
 
-// Pass 2: Apply accumulated gradients to embedding and clear accumulator.
+// Pass 2: apply accumulated gradients to embedding and clear the accumulator.
 //
-// The accumulated gradient is the sum of per-edge contributions (each clamped
-// to [-4, 4]). We clamp the total to [-grad_clamp, grad_clamp] to prevent
-// flyaway outliers. grad_clamp is derived from n_neighbors on the CPU side:
-//   grad_clamp = EDGE_CLAMP * sqrt(7 * n_neighbors)
-// This models the expected magnitude as a random walk over ~7K gradient
-// contributions (K attractive as head, K as tail, 5K repulsive), where
-// partially-canceling directions give sqrt(N) scaling.
+// `g` is the summed per-epoch position delta. Per-edge contributions are already
+// clamped to ±EDGE_CLAMP, so g is finite, but a vertex with coherent gradients can
+// exceed the ~sqrt(7K)·EDGE_CLAMP random-walk norm; grad_clamp caps those outliers.
+// SGD applies `α·g`; Momentum integrates `v = β·v + g; x += α·v`, whose recurrence
+// would otherwise amplify an unclamped outlier by ~1/(1-β) and over-scale the
+// layout — so the clamp is applied on BOTH paths. It matches SGD and, for typical
+// well-canceling gradients, rarely binds.
 @compute @workgroup_size(256)
 fn apply_grads(@builtin(global_invocation_id) gid: vec3<u32>) {
     let idx = gid.x + params.apply_offset;
@@ -128,9 +158,25 @@ fn apply_grads(@builtin(global_invocation_id) gid: vec3<u32>) {
         return;
     }
 
-    let g = atomicExchange(&grad_accum[idx], 0);
-    if (g != 0) {
-        let grad = clamp(from_fixed(g), -params.grad_clamp, params.grad_clamp);
-        embedding[idx] += params.alpha * grad;
+    let g = clamp(from_fixed(atomicExchange(&grad_accum[idx], 0)), -params.grad_clamp, params.grad_clamp);
+    if (params.optimizer == 1u) {
+        let v = params.beta * velocity[idx] + g;
+        velocity[idx] = v;
+        embedding[idx] += params.alpha * v;
+    } else {
+        embedding[idx] += params.alpha * g;
     }
+}
+
+// Pass 3: subtract a baseline from both schedule counters (called when the f32
+// epoch coordinate grows large) so precision is retained over long runs.
+@compute @workgroup_size(256)
+fn rebase_schedule(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = params.edge_offset + gid.x;
+    if (i >= params.n_edges) {
+        return;
+    }
+    let base = f32(params.epoch);
+    eons[i] = eons[i] - base;
+    eonns[i] = eonns[i] - base;
 }


### PR DESCRIPTION
- Makes UMAP incremental: instead of computing the full layout in one blocking call, a UMAP instance is now stateful and resumable, so the layout can be advanced step by step and rendered as it evolves (real-time / interactive UMAP).
- Allows tuning the layout on the fly — parameters, optimizer, and a full restart can all be changed while UMAP is running, without rebuilding from scratch.
- Adds an entry point to run UMAP directly from a precomputed kNN graph, skipping the nearest-neighbor search.
- Adds a momentum optimizer option that produces better global structure.
- Optimizes the embedding view's statistics for streaming data so per-frame updates stay cheap.
