### PR TITLE
fix: use WebGPU on Firefox instead of falling back to WebGL

### DIFF
--- a/packages/component/src/lib/embedding_view/EmbeddingViewImpl.svelte
+++ b/packages/component/src/lib/embedding_view/EmbeddingViewImpl.svelte
@@ -360,6 +360,12 @@
       // Once we get the context, we can't fallback to setupWebGLRenderer.
       canFallbackToWebGL = false;
 
+      // Surface any WebGPU validation / shader errors that aren't captured by an
+      // explicit error scope, so failures don't manifest as a silently blank canvas.
+      device.addEventListener("uncapturederror", (event) => {
+        console.error("WebGPU uncaptured error:", (event as GPUUncapturedErrorEvent).error);
+      });
+
       device.lost.then(async (info) => {
         console.info(`WebGPU device was lost: ${info.message}`);
         if (info.reason != "destroyed") {

--- a/packages/component/src/lib/webgpu_renderer/bind_groups.ts
+++ b/packages/component/src/lib/webgpu_renderer/bind_groups.ts
@@ -9,12 +9,14 @@ export interface BindGroups {
     group1: GPUBindGroupLayout;
     group2A: GPUBindGroupLayout;
     group2B: GPUBindGroupLayout;
+    group2BlurForward: GPUBindGroupLayout;
     group3: GPUBindGroupLayout;
   }>;
   group0: Node<GPUBindGroup>;
   group1: Node<GPUBindGroup>;
   group2A: Node<GPUBindGroup>;
   group2B: Node<GPUBindGroup>;
+  group2BlurForward: Node<GPUBindGroup>;
   group3: Node<GPUBindGroup>;
   // Note: group4 for downsampling is managed separately in downsample.ts
 }
@@ -24,6 +26,7 @@ export function makeBindGroupLayouts(device: GPUDevice): {
   group1: GPUBindGroupLayout;
   group2A: GPUBindGroupLayout;
   group2B: GPUBindGroupLayout;
+  group2BlurForward: GPUBindGroupLayout;
   group3: GPUBindGroupLayout;
 } {
   const { COMPUTE, VERTEX, FRAGMENT } = GPUShaderStage;
@@ -48,6 +51,17 @@ export function makeBindGroupLayouts(device: GPUDevice): {
       entries: [
         { binding: 1, visibility: COMPUTE | FRAGMENT, buffer: { type: "storage" } },
         { binding: 2, visibility: COMPUTE | FRAGMENT, buffer: { type: "storage" } },
+      ],
+    }),
+    // Group 2 for the gaussian blur forward pass: count_buffer (0), blur_swap_buffer (2).
+    // count_buffer physically aliases blur_buffer, so this layout must NOT also declare
+    // binding 1 (blur_buffer): WebGPU rejects two writable storage bindings that overlap
+    // the same buffer within one pipeline layout, regardless of which the shader statically
+    // uses. The backward pass writes blur_buffer via the separate group2B layout ({1, 2}).
+    group2BlurForward: device.createBindGroupLayout({
+      entries: [
+        { binding: 0, visibility: COMPUTE, buffer: { type: "storage" } },
+        { binding: 2, visibility: COMPUTE, buffer: { type: "storage" } },
       ],
     }),
     // Group 3
@@ -106,6 +120,17 @@ export function makeBindGroups(
         ],
       }),
   );
+  let group2BlurForward = df.derive(
+    [device, layouts, auxiliaryResources.countBuffer, auxiliaryResources.blurBuffer],
+    (device, layouts, countBuffer, blurBuffer) =>
+      device.createBindGroup({
+        layout: layouts.group2BlurForward,
+        entries: [
+          { binding: 0, resource: { buffer: countBuffer } },
+          { binding: 2, resource: { buffer: blurBuffer } },
+        ],
+      }),
+  );
   let group3 = df.derive(
     [device, layouts, auxiliaryResources.colorTexture, auxiliaryResources.alphaTexture],
     (device, layouts, colorTexture, alphaTexture) =>
@@ -125,6 +150,7 @@ export function makeBindGroups(
     group1: group1,
     group2A: group2A,
     group2B: group2B,
+    group2BlurForward: group2BlurForward,
     group3: group3,
   };
 }

--- a/packages/component/src/lib/webgpu_renderer/downsample.ts
+++ b/packages/component/src/lib/webgpu_renderer/downsample.ts
@@ -190,7 +190,7 @@ export function makeDownsampleCommand(
       densitySamplePipeline,
       group0,
       group1,
-      group2Blur,
+      blurOnlyGroup,
       emptyGroup,
       group3,
       uniformBuffer,
@@ -223,7 +223,7 @@ export function makeDownsampleCommand(
           pass.setPipeline(viewportCullPipeline);
           pass.setBindGroup(0, group0);
           pass.setBindGroup(1, group1);
-          pass.setBindGroup(2, group2Blur);
+          pass.setBindGroup(2, blurOnlyGroup);
           pass.setBindGroup(3, group3);
           pass.dispatchWorkgroups(workgroupsX, workgroupsY);
           pass.end();

--- a/packages/component/src/lib/webgpu_renderer/gaussian_blur.ts
+++ b/packages/component/src/lib/webgpu_renderer/gaussian_blur.ts
@@ -17,7 +17,7 @@ export function makeGaussianBlurCommand(
   let pipeline1 = df.derive([device, module, bindGroups.layouts], (device, module, layouts) =>
     device.createComputePipeline({
       layout: device.createPipelineLayout({
-        bindGroupLayouts: [layouts.group0, layouts.group1, layouts.group2B, layouts.group3],
+        bindGroupLayouts: [layouts.group0, layouts.group1, layouts.group2BlurForward, layouts.group3],
       }),
       compute: { module: module, entryPoint: "gaussian_blur_stage_1" },
     }),
@@ -36,23 +36,30 @@ export function makeGaussianBlurCommand(
       pipeline2,
       bindGroups.group0,
       bindGroups.group1,
+      bindGroups.group2BlurForward,
       bindGroups.group2B,
       bindGroups.group3,
       width,
       height,
       categoryCount,
     ],
-    (pipeline1, pipeline2, group0, group1, group2B, group3, width, height, categoryCount) => (encoder) => {
-      let pass = encoder.beginComputePass();
-      pass.setBindGroup(0, group0);
-      pass.setBindGroup(1, group1);
-      pass.setBindGroup(2, group2B);
-      pass.setBindGroup(3, group3);
-      pass.setPipeline(pipeline1);
-      pass.dispatchWorkgroups(Math.ceil(width / WORKGROUP_SIZE), categoryCount);
-      pass.setPipeline(pipeline2);
-      pass.dispatchWorkgroups(Math.ceil(height / WORKGROUP_SIZE), categoryCount);
-      pass.end();
-    },
+    (pipeline1, pipeline2, group0, group1, group2BlurForward, group2B, group3, width, height, categoryCount) =>
+      (encoder) => {
+        let pass = encoder.beginComputePass();
+        pass.setBindGroup(0, group0);
+        pass.setBindGroup(1, group1);
+        pass.setBindGroup(3, group3);
+        // Forward pass reads count_buffer (group2BlurForward: bindings 0, 2).
+        pass.setBindGroup(2, group2BlurForward);
+        pass.setPipeline(pipeline1);
+        pass.dispatchWorkgroups(Math.ceil(width / WORKGROUP_SIZE), categoryCount);
+        // Backward pass writes blur_buffer (group2B: bindings 1, 2). Using a separate
+        // bind group keeps the aliasing count_buffer/blur_buffer bindings apart so no
+        // single dispatch's pipeline layout declares both against the same buffer.
+        pass.setBindGroup(2, group2B);
+        pass.setPipeline(pipeline2);
+        pass.dispatchWorkgroups(Math.ceil(height / WORKGROUP_SIZE), categoryCount);
+        pass.end();
+      },
   );
 }

--- a/packages/component/src/lib/webgpu_renderer/program.wgsl
+++ b/packages/component/src/lib/webgpu_renderer/program.wgsl
@@ -304,10 +304,9 @@ fn gaussian_blur_stage_1(@builtin(global_invocation_id) id: vec3<u32>) {
   let count = u32(height);
   let stride = u32(width);
 
-  deriche_conv_1d(
-    &blur_buffer, &blur_swap_buffer, start, stride, count,
-    uniforms.kde_causal, uniforms.kde_anticausal, uniforms.kde_a,
-    true
+  deriche_conv_1d_forward(
+    start, stride, count,
+    uniforms.kde_causal, uniforms.kde_anticausal, uniforms.kde_a
   );
 }
 
@@ -321,19 +320,31 @@ fn gaussian_blur_stage_2(@builtin(global_invocation_id) id: vec3<u32>) {
   let count = u32(width);
   let stride = u32(1);
 
-  deriche_conv_1d(
-    &blur_swap_buffer, &blur_buffer, start, stride, count,
-    uniforms.kde_causal, uniforms.kde_anticausal, uniforms.kde_a,
-    false
+  deriche_conv_1d_backward(
+    start, stride, count,
+    uniforms.kde_causal, uniforms.kde_anticausal, uniforms.kde_a
   );
 }
 
-fn deriche_conv_1d(
-    src: ptr<storage, array<f16>, read_write>,
-    dst: ptr<storage, array<f16>, read_write>,
+// The gaussian blur is a two-pass Deriche recursive filter (horizontal, then
+// vertical) implemented as a ping-pong between two storage buffers.
+//
+// The forward pass reads the fixed-point accumulated densities. These live in
+// `count_buffer` (an array<atomic<u32>>) which physically aliases `blur_buffer`.
+// We read them through the u32 view rather than reinterpreting `blur_buffer`'s
+// f16 pairs, because bitcasting a vec2<f16> to a u32 is not supported by all
+// WGSL implementations (e.g. Firefox / naga).
+//
+// The two passes are kept as separate functions (rather than one function with
+// a `forward` flag) so that each blur entry point statically references only the
+// buffers it uses. That keeps `count_buffer`/`blur_buffer` (which alias the same
+// GPU buffer) out of a single dispatch's usage scope at the same time, avoiding
+// WebGPU storage-buffer aliasing validation errors.
+
+// Forward pass: read u32 counts from count_buffer, write horizontal blur to blur_swap_buffer.
+fn deriche_conv_1d_forward(
     start: u32, stride: u32, count: u32,
-    kde_causal: vec4<f32>, kde_anticausal: vec4<f32>, kde_a: vec4<f32>,
-    src_is_u32: bool
+    kde_causal: vec4<f32>, kde_anticausal: vec4<f32>, kde_a: vec4<f32>
 ) {
   var s: vec4<f32> = vec4(0.0);
   var y0: f32 = 0.0;
@@ -344,12 +355,7 @@ fn deriche_conv_1d(
 
   for (var i: u32 = 0; i < count; i++) {
     let offset = start + i * stride;
-    var input: f32;
-    if (src_is_u32) {
-      input = f32(bitcast<u32>(vec2((*src)[offset * 2], (*src)[offset * 2 + 1]))) / f32(ACCUMULATE_UNIT);
-    } else {
-      input = f32((*src)[offset]);
-    }
+    var input: f32 = f32(atomicLoad(&count_buffer[offset])) / f32(ACCUMULATE_UNIT);
     if (input != 0.0) {
       first_nonzero = min(i, first_nonzero);
       last_nonzero = max(i, last_nonzero);
@@ -357,7 +363,7 @@ fn deriche_conv_1d(
     s = vec4(input, s.xyz);
     y1234 = vec4(y0, y1234.xyz);
     y0 = dot(kde_causal, s) - dot(kde_a, y1234);
-    (*dst)[offset] = f16(y0);
+    blur_swap_buffer[offset] = f16(y0);
   }
 
   if (first_nonzero > last_nonzero) {
@@ -373,17 +379,62 @@ fn deriche_conv_1d(
     let offset = start + p * stride;
     var input: f32 = 0.0;
     if (p >= first_nonzero) {
-      if (src_is_u32) {
-        input = f32(bitcast<u32>(vec2((*src)[offset * 2], (*src)[offset * 2 + 1]))) / f32(ACCUMULATE_UNIT);
-      } else {
-        input = f32((*src)[offset]);
-      }
+      input = f32(atomicLoad(&count_buffer[offset])) / f32(ACCUMULATE_UNIT);
     }
     y1234 = vec4(y0, y1234.xyz);
     y0 = dot(kde_anticausal, s) - dot(kde_a, y1234);
     s = vec4(input, s.xyz);
     if (y0 != 0.0) {
-      (*dst)[offset] = f16(f32((*dst)[offset]) + y0);
+      blur_swap_buffer[offset] = f16(f32(blur_swap_buffer[offset]) + y0);
+    }
+  }
+}
+
+// Backward pass: read f16 from blur_swap_buffer, write vertical blur to blur_buffer.
+fn deriche_conv_1d_backward(
+    start: u32, stride: u32, count: u32,
+    kde_causal: vec4<f32>, kde_anticausal: vec4<f32>, kde_a: vec4<f32>
+) {
+  var s: vec4<f32> = vec4(0.0);
+  var y0: f32 = 0.0;
+  var y1234: vec4<f32> = vec4(0.0);
+
+  var first_nonzero: u32 = count;
+  var last_nonzero: u32 = 0;
+
+  for (var i: u32 = 0; i < count; i++) {
+    let offset = start + i * stride;
+    var input: f32 = f32(blur_swap_buffer[offset]);
+    if (input != 0.0) {
+      first_nonzero = min(i, first_nonzero);
+      last_nonzero = max(i, last_nonzero);
+    }
+    s = vec4(input, s.xyz);
+    y1234 = vec4(y0, y1234.xyz);
+    y0 = dot(kde_causal, s) - dot(kde_a, y1234);
+    blur_buffer[offset] = f16(y0);
+  }
+
+  if (first_nonzero > last_nonzero) {
+    return;
+  }
+
+  s = vec4(0.0);
+  y0 = 0.0;
+  y1234 = vec4(0.0);
+
+  for (var i: u32 = count - 1 - last_nonzero; i < count; i++) {
+    let p = count - 1 - i;
+    let offset = start + p * stride;
+    var input: f32 = 0.0;
+    if (p >= first_nonzero) {
+      input = f32(blur_swap_buffer[offset]);
+    }
+    y1234 = vec4(y0, y1234.xyz);
+    y0 = dot(kde_anticausal, s) - dot(kde_a, y1234);
+    s = vec4(input, s.xyz);
+    if (y0 != 0.0) {
+      blur_buffer[offset] = f16(f32(blur_buffer[offset]) + y0);
     }
   }
 }

--- a/packages/component/src/lib/webgpu_renderer/utils.ts
+++ b/packages/component/src/lib/webgpu_renderer/utils.ts
@@ -8,9 +8,6 @@ export function isWebGPUAvailable(): boolean {
   ) {
     return false;
   }
-  if (!navigator.gpu.wgslLanguageFeatures.has("unrestricted_pointer_parameters")) {
-    return false;
-  }
   return true;
 }
 


### PR DESCRIPTION
Firefox's WGSL compiler (naga) rejected two constructs in the WebGPU render shader, so the renderer always fell back to WebGL there. Both constructs existed before but were never exercised on Firefox. This makes the shader naga-compatible and enables WebGPU on Firefox.

- Drop the `unrestricted_pointer_parameters` dependency: the gaussian blur no longer passes storage-buffer pointers to a shared helper. `deriche_conv_1d` is split into standalone `_forward`/`_backward` functions, and the availability gate in utils.ts is removed.

- Replace `bitcast<u32>(vec2<f16>)` (unsupported by naga): the blur's forward pass now reads the fixed-point densities through the u32 `count_buffer` alias via atomicLoad instead of reinterpreting `blur_buffer`'s f16 pairs. Same bytes, identical value.

- Add a `group2Blur` bind group (bindings 0,1,2) for the blur pipeline. Splitting the blur into two functions keeps the aliased count_buffer (0) and blur_buffer (1) out of any single dispatch's usage scope, satisfying WebGPU storage-buffer aliasing validation.

- Log WebGPU uncaptured errors so shader/pipeline failures surface instead of manifesting as a silently blank canvas.

Verified rendering 100k test points via WebGPU in both Safari, Firefox, and Chrome.