### PR TITLE
fix: add --device option for embedding models

### DIFF
--- a/packages/backend/embedding_atlas/cli.py
+++ b/packages/backend/embedding_atlas/cli.py
@@ -177,6 +177,11 @@ def import_modules(names: list[str]):
     help="Model name for generating embeddings (e.g., 'all-MiniLM-L6-v2').",
 )
 @click.option(
+    "--device",
+    default=None,
+    help="PyTorch device for embedding models (e.g., 'cpu', 'cuda', 'mps', or 'cuda:0').",
+)
+@click.option(
     "--trust-remote-code",
     is_flag=True,
     default=False,
@@ -356,6 +361,7 @@ def main(
     split: list[str] | None,
     enable_projection: bool,
     model: str | None,
+    device: str | None,
     trust_remote_code: bool,
     batch_size: int | None,
     embedder: str | None,
@@ -453,6 +459,8 @@ def main(
 
             # Build embedder_args from CLI options
             embedder_args = {}
+            if device is not None:
+                embedder_args["device"] = device
             if trust_remote_code:
                 embedder_args["trust_remote_code"] = True
             if api_key is not None:

--- a/packages/backend/embedding_atlas/embedding.py
+++ b/packages/backend/embedding_atlas/embedding.py
@@ -137,8 +137,11 @@ def _create_transformers_audio_embedder(
     model_name = model or "laion/clap-htsat-fused"
     logger.info("Loading CLAP model %s...", model_name)
 
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-    clap_model = ClapModel.from_pretrained(model_name, **embedder_args).to(device)  # type: ignore
+    model_args = dict(embedder_args)
+    device = model_args.pop("device", None)
+    if device is None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+    clap_model = ClapModel.from_pretrained(model_name, **model_args).to(device)  # type: ignore
     clap_processor = ClapProcessor.from_pretrained(model_name)
 
     target_sr = clap_processor.feature_extractor.sampling_rate  # type: ignore

--- a/packages/backend/tests/test_cli.py
+++ b/packages/backend/tests/test_cli.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+import pandas as pd
+from click.testing import CliRunner
+
+from embedding_atlas import cli, projection
+
+
+def test_device_is_forwarded_in_embedder_args(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_compute_projection(data, **kwargs):
+        captured.update(kwargs)
+        result = data.copy()
+        result[kwargs["x"]] = 0.0
+        result[kwargs["y"]] = 0.0
+        if kwargs["neighbors"] is not None:
+            result[kwargs["neighbors"]] = [{"ids": [], "distances": []}]
+        return result
+
+    class FakeDataSource:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def export_to_folder(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(
+        cli, "load_datasets", lambda *args, **kwargs: pd.DataFrame({"text": ["hi"]})
+    )
+    monkeypatch.setattr(projection, "compute_projection", fake_compute_projection)
+    monkeypatch.setattr(cli, "DataSource", FakeDataSource)
+
+    result = CliRunner().invoke(
+        cli.main,
+        [
+            "input.parquet",
+            "--text",
+            "text",
+            "--device",
+            "cpu",
+            "--export-application",
+            str(tmp_path / "export"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["embedder_args"] == {"device": "cpu"}

--- a/packages/backend/tests/test_embedding_device.py
+++ b/packages/backend/tests/test_embedding_device.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+import asyncio
+import sys
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from embedding_atlas.embedding import (
+    _create_sentence_transformers_embedder,
+    _create_transformers_audio_embedder,
+    _create_transformers_image_embedder,
+    _create_transformers_text_embedder,
+)
+from embedding_atlas.projection import _caching_embedder_args
+
+
+def test_device_is_included_in_projection_cache_args():
+    assert _caching_embedder_args({"device": "cpu"}) == {"device": "cpu"}
+
+
+def test_sentence_transformers_forwards_device(monkeypatch):
+    sentence_transformer = MagicMock()
+    monkeypatch.setitem(
+        sys.modules,
+        "sentence_transformers",
+        SimpleNamespace(SentenceTransformer=sentence_transformer),
+    )
+
+    _create_sentence_transformers_embedder(
+        modality="text", model="test-model", embedder_args={"device": "cpu"}
+    )
+
+    sentence_transformer.assert_called_once_with(
+        "test-model", trust_remote_code=False, device="cpu"
+    )
+
+
+def test_transformers_text_forwards_device(monkeypatch):
+    pipeline = MagicMock()
+    monkeypatch.setitem(sys.modules, "transformers", SimpleNamespace(pipeline=pipeline))
+
+    _create_transformers_text_embedder(
+        model="test-model", embedder_args={"device": "mps"}
+    )
+
+    pipeline.assert_called_once_with(
+        "feature-extraction", model="test-model", device="mps"
+    )
+
+
+def test_transformers_image_forwards_device(monkeypatch):
+    pipeline = MagicMock()
+    monkeypatch.setitem(sys.modules, "transformers", SimpleNamespace(pipeline=pipeline))
+
+    _create_transformers_image_embedder(
+        model="test-model", embedder_args={"device": "cuda:0"}
+    )
+
+    pipeline.assert_called_once_with(
+        "image-feature-extraction", model="test-model", device="cuda:0"
+    )
+
+
+def test_transformers_audio_moves_model_and_tensors_to_device(monkeypatch):
+    model_device = None
+    inputs_device = None
+
+    class FakeTensor:
+        def cpu(self):
+            return self
+
+        def float(self):
+            return self
+
+        def numpy(self):
+            return np.array([[1.0, 2.0]], dtype=np.float32)
+
+    class FakeModel:
+        def to(self, device):
+            nonlocal model_device
+            model_device = device
+            return self
+
+        def get_audio_features(self, **inputs):
+            return FakeTensor()
+
+    class FakeInputs(dict):
+        def to(self, device):
+            nonlocal inputs_device
+            inputs_device = device
+            return self
+
+    class FakeProcessor:
+        feature_extractor = SimpleNamespace(sampling_rate=16_000)
+
+        def __call__(self, **kwargs):
+            return FakeInputs(input_values=kwargs["audio"])
+
+    clap_model = MagicMock()
+    clap_model.from_pretrained.return_value = FakeModel()
+    clap_processor = MagicMock()
+    clap_processor.from_pretrained.return_value = FakeProcessor()
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        SimpleNamespace(ClapModel=clap_model, ClapProcessor=clap_processor),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "torch",
+        SimpleNamespace(
+            cuda=SimpleNamespace(is_available=lambda: True),
+            no_grad=nullcontext,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "soundfile",
+        SimpleNamespace(
+            read=lambda _: (np.array([0.1, 0.2], dtype=np.float32), 16_000)
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "scipy.signal",
+        SimpleNamespace(resample=lambda data, _: data),
+    )
+
+    embed = _create_transformers_audio_embedder(
+        model="test-model",
+        embedder_args={"device": "cpu", "trust_remote_code": True},
+    )
+    result = asyncio.run(embed([{"bytes": b"audio"}], model=None, embedder_args={}))
+
+    clap_model.from_pretrained.assert_called_once_with(
+        "test-model", trust_remote_code=True
+    )
+    assert model_device == "cpu"
+    assert inputs_device == "cpu"
+    np.testing.assert_array_equal(result, [[1.0, 2.0]])

--- a/packages/docs/tool.md
+++ b/packages/docs/tool.md
@@ -51,6 +51,8 @@ embedding-atlas huggingface_org/dataset_name
 
 The script will compute embedding vectors for the specified column containing the text, image, or audio data. By default, it uses [SentenceTransformers](https://sbert.net/) for text and [HuggingFace Transformers](https://huggingface.co/docs/transformers/) for images and audio. You can also use [LiteLLM](https://docs.litellm.ai/) for API-based embeddings via `--embedder litellm`. Use the `--model` option to specify an embedding model. If not specified, a default model will be used. The current defaults are `all-MiniLM-L6-v2` for text, `google/vit-base-patch16-224` for images, and `laion/clap-htsat-fused` for audio, but these are subject to change in future releases.
 
+Use `--device` to select the PyTorch device used for embedding, such as `cpu`, `cuda`, `mps`, or an indexed CUDA device like `cuda:0`. For example, use `--device cpu` to force CPU execution when PyTorch detects a GPU that the installed PyTorch build does not support.
+
 After embedding vectors are computed, the script will then project the high-dimensional vectors to 2D with [UMAP](https://umap-learn.readthedocs.io/en/latest/index.html).
 
 ::: tip


### PR DESCRIPTION
## Summary

- expose a `--device` CLI option and forward it through `embedder_args`
- support explicit devices for SentenceTransformers and Transformers text/image pipelines
- handle CLAP separately by moving the model and processed tensors to the selected device
- retain the selected device in projection cache keys
- document CPU, CUDA, MPS, and indexed CUDA device selection

## Problem

PyTorch can detect a CUDA GPU whose compute capability is unsupported by the installed build. Embedding Atlas then attempts GPU execution and fails before launch, even though its embedding backends already accept an explicit device. The CLI had no way to force CPU execution.

This change exposes that existing capability through `--device`. CLAP is handled separately because its `from_pretrained` method does not accept `device`; the model and processed tensor batch are moved to the selected device instead.

## Testing

- added mocked tests for CLI forwarding
- added mocked tests for SentenceTransformers, Transformers text/image pipelines, and CLAP audio
- full backend suite: 149 passed, 21 skipped
- repository Prettier and Ruff checks pass
- manually completed a SentenceTransformers projection with device set to CPU

Fixes #60