### PR TITLE
fix: show error when embedding renderer is unavailable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9319,6 +9319,7 @@
         "svelte-check": "^4.4.5",
         "typescript": "^5.9.3",
         "vite": "^8.0.1",
+        "vitest": "^4.1.0",
         "vite-plugin-dts": "^4.5.4",
         "vite-plugin-wasm": "^3.6.0"
       },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "build": "./scripts/build.sh",
-    "test:js": "npm run test -w @embedding-atlas/density-clustering -w @embedding-atlas/umap-wasm -w @embedding-atlas/utils -w @embedding-atlas/viewer",
+    "test:js": "npm run test -w @embedding-atlas/density-clustering -w @embedding-atlas/umap-wasm -w @embedding-atlas/utils -w @embedding-atlas/component -w @embedding-atlas/viewer",
     "test:rust": "cargo test --workspace",
     "test:python": "cd packages/backend && uv run pytest",
     "test": "npm run test:js && npm run test:python && npm run test:rust",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "check": "svelte-check",
+    "test": "vitest run --config vitest.config.js",
     "package": "npm run build && publint",
     "preview": "vite preview"
   },
@@ -54,6 +55,7 @@
     "svelte-check": "^4.4.5",
     "typescript": "^5.9.3",
     "vite": "^8.0.1",
+    "vitest": "^4.1.0",
     "vite-plugin-dts": "^4.5.4",
     "vite-plugin-wasm": "^3.6.0"
   },

--- a/packages/component/src/lib/embedding_view/EmbeddingViewImpl.svelte
+++ b/packages/component/src/lib/embedding_view/EmbeddingViewImpl.svelte
@@ -101,6 +101,11 @@
   import { defaultCategoryColors } from "../colors.js";
   import type { EmbeddingRenderer } from "../renderer_interface.js";
   import {
+    initializeRendererWithFallback,
+    RENDERER_UNAVAILABLE_MESSAGE,
+    RENDERER_UNAVAILABLE_TITLE,
+  } from "../renderer_selection.js";
+  import {
     cacheKeyForObject,
     deepEquals,
     pointDistance,
@@ -220,6 +225,7 @@
   let canvas: HTMLCanvasElement | null = $state(null);
   let renderer: EmbeddingRenderer | null = $state(null);
   let webGPUPrompt: string | null = $state(null);
+  let rendererError: string | null = $state(null);
 
   let minimumDensity = $derived(config?.minimumDensity ?? 1 / 16);
   let userPointSize = $derived(config?.pointSize ?? null);
@@ -305,24 +311,26 @@
     }
   }
 
-  function setupWebGLRenderer(canvas: HTMLCanvasElement) {
-    webGPUPrompt = "WebGPU is unavailable. Falling back to WebGL.";
-
+  function setupWebGLRenderer(canvas: HTMLCanvasElement): boolean {
     let context: WebGL2RenderingContext | null;
 
-    function createRenderer() {
+    function createRenderer(): boolean {
       context = canvas.getContext("webgl2", { antialias: false });
       if (context == null) {
         console.error("Could not get WebGL 2 context");
-        return;
+        return false;
       }
       context.getExtension("EXT_color_buffer_float");
       context.getExtension("EXT_float_blend");
       context.getExtension("OES_texture_float_linear");
       renderer = new EmbeddingRendererWebGL2(context, pixelWidth, pixelHeight);
+      rendererError = null;
+      return true;
     }
 
-    createRenderer();
+    if (!createRenderer()) {
+      return false;
+    }
 
     canvas.addEventListener("webglcontextlost", () => {
       renderer?.destroy();
@@ -331,34 +339,27 @@
     });
 
     canvas.addEventListener("webglcontextrestored", () => {
-      createRenderer();
+      if (!createRenderer()) {
+        rendererError = RENDERER_UNAVAILABLE_MESSAGE;
+      }
     });
+
+    return true;
   }
 
-  function setupWebGPURenderer(canvas: HTMLCanvasElement) {
-    let canFallbackToWebGL = true;
-
-    async function createRenderer() {
+  async function setupWebGPURenderer(canvas: HTMLCanvasElement): Promise<boolean> {
+    async function createRenderer(): Promise<boolean> {
       let device = await requestWebGPUDevice();
       if (device == null) {
         console.error("Could not get WebGPU device");
-        if (canFallbackToWebGL) {
-          setupWebGLRenderer(canvas);
-        }
-        return;
+        return false;
       }
 
       let context = canvas.getContext("webgpu");
       if (context == null) {
         console.error("Could not get WebGPU canvas context");
-        if (canFallbackToWebGL) {
-          setupWebGLRenderer(canvas);
-        }
-        return;
+        return false;
       }
-
-      // Once we get the context, we can't fallback to setupWebGLRenderer.
-      canFallbackToWebGL = false;
 
       // Surface any WebGPU validation / shader errors that aren't captured by an
       // explicit error scope, so failures don't manifest as a silently blank canvas.
@@ -372,7 +373,9 @@
           renderer?.destroy();
           renderer = null;
           context.unconfigure();
-          await createRenderer();
+          if (!(await createRenderer())) {
+            rendererError = RENDERER_UNAVAILABLE_MESSAGE;
+          }
         }
       });
 
@@ -385,9 +388,11 @@
       });
 
       renderer = new EmbeddingRendererWebGPU(context, device, format, pixelWidth, pixelHeight);
+      rendererError = null;
+      return true;
     }
 
-    createRenderer();
+    return await createRenderer();
   }
 
   function syncViewportState(defaultViewportState: ViewportState | null) {
@@ -402,15 +407,25 @@
     if (canvas == null) {
       return;
     }
-    // Setup WebGPU renderer (with fallback to WebGL)
-    setupWebGPURenderer(canvas);
+    const mountedCanvas = canvas;
+    // Setup WebGPU renderer (with fallback to WebGL2)
+    initializeRendererWithFallback(
+      () => setupWebGPURenderer(mountedCanvas),
+      () => setupWebGLRenderer(mountedCanvas),
+    ).then((backend) => {
+      if (backend == "webgl2") {
+        webGPUPrompt = "WebGPU is unavailable. Using WebGL 2.";
+      } else if (backend == null) {
+        rendererError = RENDERER_UNAVAILABLE_MESSAGE;
+      }
+    });
 
     // Override toDataURL. This is because we must submit the render commands before
     // calling toDataURL, to ensure the current image is populated with contents.
-    let _toDataURL = canvas.toDataURL;
-    canvas.toDataURL = (...args) => {
+    let _toDataURL = mountedCanvas.toDataURL;
+    mountedCanvas.toDataURL = (...args) => {
       render();
-      return _toDataURL.apply(canvas, args);
+      return _toDataURL.apply(mountedCanvas, args);
     };
   });
 
@@ -860,6 +875,32 @@
       {/if}
     {/if}
   </svg>
+  {#if rendererError != null}
+    <div
+      role="alert"
+      aria-live="assertive"
+      style:position="absolute"
+      style:inset="0"
+      style:z-index="1"
+      style:display="flex"
+      style:align-items="center"
+      style:justify-content="center"
+      style:padding="24px"
+      style:font-family={resolvedTheme.fontFamily}
+      style:color={resolvedTheme.statusBarTextColor}
+    >
+      <div
+        style:max-width="520px"
+        style:padding="16px 20px"
+        style:border-radius="6px"
+        style:text-align="center"
+        style:background={resolvedTheme.statusBarBackgroundColor}
+      >
+        <div style:font-weight="600" style:margin-bottom="6px">{RENDERER_UNAVAILABLE_TITLE}</div>
+        <div>{rendererError}</div>
+      </div>
+    </div>
+  {/if}
   <!-- Tooltip popup -->
   {#if tooltip != null && renderer != null}
     {@const loc = pointLocation(tooltip.x, tooltip.y)}
@@ -878,7 +919,7 @@
   {#if resolvedTheme.statusBar}
     <StatusBar
       resolvedTheme={resolvedTheme}
-      statusMessage={statusMessage ?? webGPUPrompt}
+      statusMessage={statusMessage ?? (rendererError != null ? RENDERER_UNAVAILABLE_TITLE : webGPUPrompt)}
       distancePerPoint={1 / (pointLocation(1, 0).x - pointLocation(0, 0).x)}
       pointCount={data.x.length}
       selectionMode={selectionMode}

--- a/packages/component/src/lib/renderer_selection.ts
+++ b/packages/component/src/lib/renderer_selection.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+export type RendererBackend = "webgpu" | "webgl2";
+
+export const RENDERER_UNAVAILABLE_TITLE = "Unable to render embedding";
+
+export const RENDERER_UNAVAILABLE_MESSAGE =
+  "Embedding Atlas requires WebGPU or WebGL 2, but neither could be initialized. Check that browser hardware acceleration is enabled and that your browser and graphics drivers are up to date.";
+
+/** Try WebGPU first, then WebGL2, without letting one failed attempt abort fallback. */
+export async function initializeRendererWithFallback(
+  tryWebGPU: () => boolean | Promise<boolean>,
+  tryWebGL2: () => boolean | Promise<boolean>,
+  onError: (error: unknown) => void = console.error,
+): Promise<RendererBackend | null> {
+  try {
+    if (await tryWebGPU()) {
+      return "webgpu";
+    }
+  } catch (error) {
+    onError(error);
+  }
+
+  try {
+    if (await tryWebGL2()) {
+      return "webgl2";
+    }
+  } catch (error) {
+    onError(error);
+  }
+
+  return null;
+}

--- a/packages/component/test/renderer_selection.test.ts
+++ b/packages/component/test/renderer_selection.test.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+import { describe, expect, it, vi } from "vitest";
+
+import { initializeRendererWithFallback, RENDERER_UNAVAILABLE_MESSAGE } from "../src/lib/renderer_selection.js";
+
+describe("initializeRendererWithFallback", () => {
+  it("uses WebGPU without trying WebGL2 when WebGPU succeeds", async () => {
+    const tryWebGPU = vi.fn().mockResolvedValue(true);
+    const tryWebGL2 = vi.fn().mockReturnValue(true);
+
+    await expect(initializeRendererWithFallback(tryWebGPU, tryWebGL2)).resolves.toBe("webgpu");
+    expect(tryWebGL2).not.toHaveBeenCalled();
+  });
+
+  it("falls back to WebGL2 when WebGPU is unavailable", async () => {
+    const tryWebGPU = vi.fn().mockResolvedValue(false);
+    const tryWebGL2 = vi.fn().mockReturnValue(true);
+
+    await expect(initializeRendererWithFallback(tryWebGPU, tryWebGL2)).resolves.toBe("webgl2");
+    expect(tryWebGL2).toHaveBeenCalledOnce();
+  });
+
+  it("returns null when neither renderer can be initialized", async () => {
+    await expect(
+      initializeRendererWithFallback(
+        async () => false,
+        () => false,
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it("still tries WebGL2 when WebGPU initialization throws", async () => {
+    const error = new Error("WebGPU failed");
+    const onError = vi.fn();
+
+    await expect(
+      initializeRendererWithFallback(
+        async () => {
+          throw error;
+        },
+        () => true,
+        onError,
+      ),
+    ).resolves.toBe("webgl2");
+    expect(onError).toHaveBeenCalledWith(error);
+  });
+
+  it("reports WebGL2 initialization errors as total failure", async () => {
+    const error = new Error("WebGL2 failed");
+    const onError = vi.fn();
+
+    await expect(
+      initializeRendererWithFallback(
+        async () => false,
+        () => {
+          throw error;
+        },
+        onError,
+      ),
+    ).resolves.toBeNull();
+    expect(onError).toHaveBeenCalledWith(error);
+  });
+});
+
+describe("renderer unavailable message", () => {
+  it("names both supported rendering APIs and suggests hardware acceleration", () => {
+    expect(RENDERER_UNAVAILABLE_MESSAGE).toContain("WebGPU");
+    expect(RENDERER_UNAVAILABLE_MESSAGE).toContain("WebGL 2");
+    expect(RENDERER_UNAVAILABLE_MESSAGE).toContain("hardware acceleration");
+  });
+});

--- a/packages/component/vitest.config.js
+++ b/packages/component/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/packages/docs/overview.md
+++ b/packages/docs/overview.md
@@ -20,6 +20,12 @@ See [Examples](./examples/) for live demos with embedding and tabular datasets.
 You can use Embedding Atlas directly from this website by [loading your own data](https://apple.github.io/embedding-atlas/app/). In this online version, Embedding Atlas will compute the embedding and projection in your browser. Your data does not leave your machine.
 :::
 
+## Browser requirements
+
+The embedding view requires WebGPU or WebGL 2. Embedding Atlas uses WebGPU when available and automatically falls back to WebGL 2 otherwise. If neither renderer can be initialized, the embedding view displays an error instead of a blank canvas.
+
+If you see this error, make sure hardware acceleration is enabled in your browser, update your browser and graphics drivers, and check that your virtual machine or remote desktop environment exposes WebGPU or WebGL 2. Other dashboard features that do not use the embedding view can still work without these rendering APIs.
+
 ## Packages
 
 Embedding Atlas is released as two packages:


### PR DESCRIPTION
## Summary

- make renderer initialization explicitly try WebGPU and then WebGL 2
- only report WebGL 2 fallback after it initializes successfully
- show an accessible, actionable error instead of a blank canvas when neither renderer is available
- add component-level tests for WebGPU success, WebGL 2 fallback, thrown initialization errors, and total failure
- document browser rendering requirements and troubleshooting

## Problem

When WebGPU initialization failed, the embedding view reported that it was falling back to WebGL even if `canvas.getContext("webgl2")` also returned `null`. Users in VMs, remote desktop sessions, and browsers without hardware acceleration then saw a blank embedding with only a console error.

The renderer now returns an explicit backend result. Successful fallback reports WebGL 2, while total failure renders a centered `role="alert"` message explaining the WebGPU/WebGL 2 requirement and suggesting hardware-acceleration, browser, and graphics-driver checks. This does not attempt software rendering when neither browser API exists.

## Testing

- `npm run build`
- `npm run check`
- `npm run test`
- `npm run check-format`

All JavaScript, Python, and Rust tests pass. Component package build, type checks, declaration generation, package linting, and documentation build also pass.

Fixes #25