### PR TITLE
feat(viewer): add controlled selection highlight

### DIFF
--- a/packages/viewer/src/EmbeddingAtlas.svelte
+++ b/packages/viewer/src/EmbeddingAtlas.svelte
@@ -35,6 +35,7 @@
     onExportSelection,
     onStateChange,
     onPredicateChange,
+    selection,
     modelContext,
     cache,
   }: EmbeddingAtlasProps = $props();
@@ -53,6 +54,7 @@
     onExportSelection,
     onStateChange,
     onPredicateChange,
+    selection,
     modelContext,
     cache,
   });
@@ -98,6 +100,10 @@
     if (chartTheme !== get(store.chartTheme)) {
       store.chartTheme.set(chartTheme ?? undefined);
     }
+  });
+
+  $effect.pre(() => {
+    store.setHighlight(selection);
   });
 
   let mcpStatus = $state.raw<string | undefined>(undefined);

--- a/packages/viewer/src/api.ts
+++ b/packages/viewer/src/api.ts
@@ -2,7 +2,7 @@
 
 // The component API for embedding viewer.
 
-import type { EmbeddingViewConfig, Label } from "@embedding-atlas/component";
+import type { DataPointID, EmbeddingViewConfig, Label } from "@embedding-atlas/component";
 import type { Coordinator } from "@uwdata/mosaic-core";
 import { createClassComponent } from "svelte/legacy";
 
@@ -93,6 +93,9 @@ export interface EmbeddingAtlasProps {
 
   /** A callback when the current filter predicate changes (e.g., due to brush or click interactions). */
   onPredicateChange?: ((predicate: string | null) => void) | null;
+
+  /** Point identifiers to highlight across the dashboard's embedding and instances views. */
+  selection?: DataPointID[] | null;
 
   /** Model context API where the component will register its tools to. */
   modelContext?: ModelContextAPI | null;

--- a/packages/viewer/src/stores/embedding_atlas_store.ts
+++ b/packages/viewer/src/stores/embedding_atlas_store.ts
@@ -1,5 +1,6 @@
 // Copyright (c) 2025 Apple Inc. Licensed under MIT License.
 
+import type { DataPointID } from "@embedding-atlas/component";
 import { deepEquals } from "@embedding-atlas/utils";
 import { type Coordinator, Selection } from "@uwdata/mosaic-core";
 import { type Draft, produce } from "immer";
@@ -114,6 +115,7 @@ export class EmbeddingAtlasStore {
       embeddingViewConfig: options.embeddingViewConfig,
       embeddingViewLabels: options.embeddingViewLabels,
     };
+    this.setHighlight(options.selection);
 
     this.search.result.subscribe((result) => {
       if (result == undefined) {
@@ -203,6 +205,14 @@ export class EmbeddingAtlasStore {
 
   getCurrentState(): EmbeddingAtlasState {
     return get(this.state);
+  }
+
+  setHighlight(selection: DataPointID[] | null | undefined) {
+    const next = selection == null ? null : [...selection];
+    if (samePointIds(get(this.chartContext.highlight), next)) {
+      return;
+    }
+    this.chartContext.highlight.set(next);
   }
 
   private _syncHistory() {
@@ -412,6 +422,13 @@ export class EmbeddingAtlasStore {
       this.chartDelegates.get(id)?.delete(delegate);
     };
   }
+}
+
+function samePointIds(left: readonly unknown[] | null, right: readonly DataPointID[] | null): boolean {
+  if (left == null || right == null) {
+    return left === right;
+  }
+  return left.length === right.length && left.every((id, index) => Object.is(id, right[index]));
 }
 
 function resolveColumnStyles(

--- a/packages/viewer/test/selection.test.ts
+++ b/packages/viewer/test/selection.test.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+import type { DataPointID } from "@embedding-atlas/component";
+import type { Coordinator } from "@uwdata/mosaic-core";
+import { get } from "svelte/store";
+import { describe, expect, it } from "vitest";
+
+import { EmbeddingAtlasStore } from "../src/stores/embedding_atlas_store.js";
+
+function coordinator(): Coordinator {
+  return {
+    query: () =>
+      Promise.resolve([
+        {
+          column_name: "id",
+          column_type: "INTEGER",
+        },
+      ]),
+  } as unknown as Coordinator;
+}
+
+async function createStore(selection: DataPointID[] | null = null): Promise<EmbeddingAtlasStore> {
+  const store = new EmbeddingAtlasStore({
+    coordinator: coordinator(),
+    data: {
+      id: "id",
+      table: "points",
+    },
+    initialState: {
+      charts: {
+        "1": { content: "Selection test", type: "markdown" },
+      },
+      currentLayout: "1",
+      layoutOrder: ["1"],
+      layouts: {
+        "1": { chartIds: ["1"], name: "Default", type: "list" },
+      },
+    },
+    selection,
+  });
+  await store.ready;
+  return store;
+}
+
+describe("EmbeddingAtlas controlled selection", () => {
+  it("initializes the shared highlight from selection with a defensive copy", async () => {
+    const selection: DataPointID[] = [7, "point-8", 9n];
+    const store = await createStore(selection);
+
+    expect(get(store.chartContext.highlight)).toEqual(selection);
+    expect(get(store.chartContext.highlight)).not.toBe(selection);
+  });
+
+  it("updates on ordered changes and deduplicates ordered-equal arrays", async () => {
+    const store = await createStore([7, "point-8", 9n]);
+    const calls: (DataPointID[] | null)[] = [];
+    const unsubscribe = store.chartContext.highlight.subscribe((value) => calls.push(value));
+
+    store.setHighlight([7, "point-8", 9n]);
+    expect(calls).toEqual([[7, "point-8", 9n]]);
+
+    const reordered: DataPointID[] = ["point-8", 7, 9n];
+    store.setHighlight(reordered);
+    reordered[0] = "mutated-outside";
+
+    expect(calls).toEqual([
+      [7, "point-8", 9n],
+      ["point-8", 7, 9n],
+    ]);
+    unsubscribe();
+  });
+
+  it("clears on null or undefined without duplicate notifications", async () => {
+    const store = await createStore([7]);
+    const calls: (DataPointID[] | null)[] = [];
+    const unsubscribe = store.chartContext.highlight.subscribe((value) => calls.push(value));
+
+    store.setHighlight(null);
+    store.setHighlight(undefined);
+
+    expect(calls).toEqual([[7], null]);
+    expect(get(store.chartContext.highlight)).toBeNull();
+    unsubscribe();
+  });
+});


### PR DESCRIPTION
## What changed

- adds a typed `selection?: DataPointID[] | null` prop to the high-level `EmbeddingAtlas` API
- initializes and reactively updates the existing shared highlight store
- defensively copies caller arrays, preserves caller order, deduplicates ordered-equal updates, and supports clearing with `null`/`undefined`
- adds focused store-level coverage for initialization, update, deduplication, copying, and clearing

## Why

The dashboard already has an internal point-highlight store, but the high-level viewer API did not expose a controlled input. Embedders therefore could not mirror an external selection into the embedding and instances views without reaching through private internals.

## Validation

- `npm run test -w @embedding-atlas/viewer` — 3 files / 36 tests passed
- focused selection test — 3/3 passed
- Prettier on all four changed paths — passed
- `git diff --check` — passed

The repository's canonical GitHub Actions workflow will run its full Rust/WASM build, workspace type checks, complete tests, formatting, and Clippy. This is opened as a draft pending that result.
