### PR TITLE
feat: layer control for embedding view

### DIFF
--- a/packages/component/src/lib/embedding_view/EmbeddingViewImpl.svelte
+++ b/packages/component/src/lib/embedding_view/EmbeddingViewImpl.svelte
@@ -152,7 +152,7 @@
     cacheIdentifier = undefined,
   }: Props<Selection> = $props();
 
-  let showClusterLabels = true;
+  let showClusterLabels = $derived(config?.showLabels ?? true);
 
   let colorScheme = $derived(config?.colorScheme ?? "light");
   let resolvedTheme = $derived(resolveTheme(theme, colorScheme));
@@ -218,6 +218,7 @@
   let minimumDensity = $derived(config?.minimumDensity ?? 1 / 16);
   let userPointSize = $derived(config?.pointSize ?? null);
   let mode = $derived(config?.mode ?? "points");
+  let showPoints = $derived(config?.showPoints ?? true);
   let autoLabelEnabled = $derived(config?.autoLabelEnabled);
   let downsampleMaxPoints = $derived(config?.downsampleMaxPoints ?? 4000000);
   let downsampleDensityWeight = $derived(config?.downsampleDensityWeight ?? 5);
@@ -261,6 +262,8 @@
       downsampleMaxPoints,
       downsampleDensityWeight,
       ...viewingParams,
+      pointAlpha: showPoints ? viewingParams.pointAlpha : 0,
+      pointsAlpha: showPoints ? viewingParams.pointsAlpha : 0,
     });
 
     if (needsRender) {

--- a/packages/component/src/lib/embedding_view/embedding_view_config.ts
+++ b/packages/component/src/lib/embedding_view/embedding_view_config.ts
@@ -7,6 +7,14 @@ export interface EmbeddingViewConfig {
   /** View mode. */
   mode?: "points" | "density" | null;
 
+  /** Whether to draw the individual points. Default: true.
+   * Set to false in "density" mode to show the density map without the points. */
+  showPoints?: boolean | null;
+
+  /** Whether to display labels, both automatically generated and explicitly provided ones.
+   * Default: true. */
+  showLabels?: boolean | null;
+
   /** Minimum average density for density contours to show up.
    * The density is measured as number of points per square points (aka., px in CSS units). */
   minimumDensity?: number | null;

--- a/packages/component/src/lib/webgpu_renderer/renderer.ts
+++ b/packages/component/src/lib/webgpu_renderer/renderer.ts
@@ -454,7 +454,9 @@ function makeRenderCommand(
           downsample(encoder, downsampleConfig);
 
           // Draw downsampled points
-          drawPointsDownsampled(encoder, count);
+          if (props.pointAlpha > 0 && props.pointsAlpha > 0) {
+            drawPointsDownsampled(encoder, count);
+          }
 
           // If in density mode, also draw density overlay (using all points, already computed)
           if (props.mode == "density") {
@@ -464,7 +466,9 @@ function makeRenderCommand(
           }
         } else {
           // No downsampling needed - use original path
-          drawPoints(encoder);
+          if (props.pointAlpha > 0 && props.pointsAlpha > 0) {
+            drawPoints(encoder);
+          }
 
           if (props.mode == "density") {
             if (props.densityAlpha > 0 || props.contoursAlpha > 0) {

--- a/packages/viewer/src/charts/embedding/Embedding.svelte
+++ b/packages/viewer/src/charts/embedding/Embedding.svelte
@@ -32,6 +32,7 @@
   import { cubicOut } from "svelte/easing";
 
   import Button from "../../widgets/Button.svelte";
+  import CheckBox from "../../widgets/CheckBox.svelte";
   import PopupButton from "../../widgets/PopupButton.svelte";
   import Select from "../../widgets/Select.svelte";
   import Slider from "../../widgets/Slider.svelte";
@@ -42,6 +43,7 @@
   import type { ChartViewProps, RowID } from "../chart.js";
   import { resolveChartTheme } from "../common/theme.js";
   import { makeCategoryColumn } from "./category_column.js";
+  import { effectiveLayers, updateLayers } from "./layers.js";
   import type { EmbeddingSpec, EmbeddingState } from "./types.js";
   import { interpolateViewport } from "./viewport_animation.js";
 
@@ -78,6 +80,8 @@
   let categoryLegend: EmbeddingLegend | null = $state.raw(null);
   let totalPointCount: number | null = $state.raw(null);
 
+  let layers = $derived(effectiveLayers(spec));
+
   // Query total point count for render limit slider
   $effect.pre(() => {
     context.coordinator
@@ -98,9 +102,9 @@
     );
     promise.then((v) => {
       categoryLegend = v;
-      if ((categoryLegend?.legend.length ?? 0) > maxCategories) {
+      if ((categoryLegend?.legend.length ?? 0) > maxCategories && effectiveLayers(spec).density) {
         onSpecChange((draft) => {
-          draft.mode = "points";
+          updateLayers(draft, { density: false });
         });
       }
     });
@@ -274,7 +278,9 @@
     config={{
       colorScheme: $colorScheme,
       ...context.embeddingViewConfig,
-      mode: spec.mode ?? "points",
+      mode: layers.density ? "density" : "points",
+      showPoints: layers.points,
+      showLabels: layers.labels,
       ...(spec.minimumDensity != null ? { minimumDensity: spec.minimumDensity } : {}),
       ...(spec.pointSize != null ? { pointSize: spec.pointSize } : {}),
       downsampleMaxPoints: spec.downsampleMaxPoints ?? defaultDownsampleMaxPoints,
@@ -386,21 +392,18 @@
       />
       <PopupButton icon={IconSettings} title="Options">
         <div class="flex flex-col gap-2 w-64">
-          <div class="text-slate-500 dark:text-slate-400 select-none">Display Mode</div>
+          <div class="text-slate-500 dark:text-slate-400 select-none">Layers</div>
+          <CheckBox
+            label="Points"
+            bind:checked={() => layers.points, (v) => onSpecChange((draft) => updateLayers(draft, { points: v }))}
+          />
           <div class="flex gap-2 items-center">
-            <Select
-              value={spec.mode ?? "points"}
-              onChange={(v) =>
-                onSpecChange((draft) => {
-                  draft.mode = v;
-                })}
+            <CheckBox
+              label="Density"
               disabled={categoryLegend != null && categoryLegend.legend.length > maxCategories}
-              options={[
-                { value: "points", label: "Points" },
-                { value: "density", label: "Density" },
-              ]}
+              bind:checked={() => layers.density, (v) => onSpecChange((draft) => updateLayers(draft, { density: v }))}
             />
-            {#if (spec.mode ?? "points") == "density"}
+            {#if layers.density}
               <Slider
                 bind:value={
                   () => Math.log((spec.minimumDensity ?? defaultMinimumDensity) / defaultMinimumDensity),
@@ -415,6 +418,10 @@
               />
             {/if}
           </div>
+          <CheckBox
+            label="Labels"
+            bind:checked={() => layers.labels, (v) => onSpecChange((draft) => updateLayers(draft, { labels: v }))}
+          />
           <div class="text-slate-500 dark:text-slate-400 select-none">Point Size</div>
           <div class="flex gap-2 items-center">
             <Slider

--- a/packages/viewer/src/charts/embedding/layers.ts
+++ b/packages/viewer/src/charts/embedding/layers.ts
@@ -12,12 +12,18 @@ function layersFromMode(mode: "points" | "density" | undefined): EmbeddingLayers
   return { points: true, density: mode == "density", labels: true };
 }
 
-/** Resolve the effective layer visibility from a spec, honoring the deprecated `mode` field. */
+/** Resolve the effective layer visibility from a spec, honoring the deprecated `mode` field.
+ * Layer entries that are null or undefined fall back to the mode-derived base. */
 export function effectiveLayers(spec: {
   mode?: "points" | "density";
   layers?: Partial<EmbeddingLayers>;
 }): EmbeddingLayers {
-  return { ...layersFromMode(spec.mode), ...spec.layers };
+  let base = layersFromMode(spec.mode);
+  return {
+    points: spec.layers?.points ?? base.points,
+    density: spec.layers?.density ?? base.density,
+    labels: spec.layers?.labels ?? base.labels,
+  };
 }
 
 /** Update layer visibility on a spec draft, migrating it away from the deprecated `mode` field. */

--- a/packages/viewer/src/charts/embedding/layers.ts
+++ b/packages/viewer/src/charts/embedding/layers.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+/** Visibility of the individual layers of the embedding view. */
+export interface EmbeddingLayers {
+  points: boolean;
+  density: boolean;
+  labels: boolean;
+}
+
+function layersFromMode(mode: "points" | "density" | undefined): EmbeddingLayers {
+  // The legacy "density" mode drew points and labels in addition to the density map.
+  return { points: true, density: mode == "density", labels: true };
+}
+
+/** Resolve the effective layer visibility from a spec, honoring the deprecated `mode` field. */
+export function effectiveLayers(spec: {
+  mode?: "points" | "density";
+  layers?: Partial<EmbeddingLayers>;
+}): EmbeddingLayers {
+  return { ...layersFromMode(spec.mode), ...spec.layers };
+}
+
+/** Update layer visibility on a spec draft, migrating it away from the deprecated `mode` field. */
+export function updateLayers(
+  spec: { mode?: "points" | "density"; layers?: Partial<EmbeddingLayers> },
+  patch: Partial<EmbeddingLayers>,
+): void {
+  spec.layers = { ...effectiveLayers(spec), ...patch };
+  delete spec.mode;
+}

--- a/packages/viewer/src/charts/embedding/types.ts
+++ b/packages/viewer/src/charts/embedding/types.ts
@@ -22,7 +22,13 @@ export interface EmbeddingSpec {
     neighbors?: string | null;
   };
 
+  /** @deprecated Superseded by `layers`. "density" turns on the density layer; kept for previously saved states. */
   mode?: "points" | "density";
+
+  /** Visibility of the view's layers. Missing entries default to points and labels on, density off,
+   * or to the equivalent of the deprecated `mode` field when it is present. */
+  layers?: { points?: boolean; density?: boolean; labels?: boolean };
+
   minimumDensity?: number;
   pointSize?: number;
   /** Maximum number of points to render (for downsampling). Default: 4000000. Set to null to disable. */

--- a/packages/viewer/src/widgets/CheckBox.svelte
+++ b/packages/viewer/src/widgets/CheckBox.svelte
@@ -5,20 +5,21 @@
   interface Props {
     checked: boolean;
     label?: string | null;
+    disabled?: boolean;
     class?: string;
   }
 
-  let { checked = $bindable(), label = null, class: className = "" }: Props = $props();
+  let { checked = $bindable(), label = null, disabled = false, class: className = "" }: Props = $props();
 </script>
 
-<label class="flex py-1 my-[1px] gap-1 items-center select-none {className}">
-  <input type="checkbox" bind:checked={checked} class="sr-only" />
+<label class="flex py-1 my-[1px] gap-1 items-center select-none {disabled ? 'pointer-events-none' : ''} {className}">
+  <input type="checkbox" bind:checked={checked} disabled={disabled} class="sr-only" />
   {#if checked}
-    <IconCheckboxChecked class="w-6 h-6 text-blue-500" />
+    <IconCheckboxChecked class="w-6 h-6 {disabled ? 'text-slate-400 dark:text-slate-500' : 'text-blue-500'}" />
   {:else}
     <IconCheckboxUnchecked class="w-6 h-6 text-slate-400 dark:text-slate-500" />
   {/if}
   {#if label != null}
-    <span class="text-[13px] dark:text-slate-300">{label}</span>
+    <span class="text-[13px] {disabled ? 'text-slate-400 dark:text-slate-500' : 'dark:text-slate-300'}">{label}</span>
   {/if}
 </label>

--- a/packages/viewer/test/embedding_layers.test.ts
+++ b/packages/viewer/test/embedding_layers.test.ts
@@ -58,6 +58,48 @@ describe("effectiveLayers", () => {
   });
 });
 
+describe("effectiveLayers edge cases", () => {
+  it("lets a full layers object turn every layer off despite legacy density mode", () => {
+    expect(effectiveLayers({ mode: "density", layers: { points: false, density: false, labels: false } })).toEqual({
+      points: false,
+      density: false,
+      labels: false,
+    });
+  });
+
+  it("treats an unrecognized legacy mode value like the default base", () => {
+    expect(effectiveLayers({ mode: "densityy" as any })).toEqual({ points: true, density: false, labels: true });
+  });
+
+  it("falls back to defaults for null layer values from hand-edited specs", () => {
+    expect(effectiveLayers({ layers: { points: null, density: null, labels: null } as any })).toEqual({
+      points: true,
+      density: false,
+      labels: true,
+    });
+  });
+
+  it("falls back to the mode base for undefined layer values", () => {
+    expect(effectiveLayers({ mode: "density", layers: { density: undefined } })).toEqual({
+      points: true,
+      density: true,
+      labels: true,
+    });
+  });
+
+  it("returns exactly the three known layer keys, dropping unknown ones", () => {
+    const result = effectiveLayers({ layers: { points: false, glow: true } as any });
+    expect(result).toEqual({ points: false, density: false, labels: true });
+    expect(Object.keys(result).sort()).toEqual(["density", "labels", "points"]);
+  });
+
+  it("does not touch spec.mode when resolving", () => {
+    const spec = { mode: "density" as const };
+    effectiveLayers(spec);
+    expect(spec.mode).toBe("density");
+  });
+});
+
 describe("updateLayers", () => {
   it("replaces a legacy mode with a complete layers object and deletes mode", () => {
     const spec: { mode?: "points" | "density"; layers?: Partial<EmbeddingLayers> } = { mode: "density" };
@@ -87,5 +129,23 @@ describe("updateLayers", () => {
     const first = { ...spec.layers };
     updateLayers(spec, { points: false });
     expect(spec.layers).toEqual(first);
+  });
+
+  it("normalizes null layer values and persists a complete object for an empty patch", () => {
+    const spec: { mode?: "points" | "density"; layers?: Partial<EmbeddingLayers> } = {
+      mode: "density",
+      layers: { labels: null } as any,
+    };
+    updateLayers(spec, {});
+    expect(spec.layers).toEqual({ points: true, density: true, labels: true });
+    expect("mode" in spec).toBe(false);
+  });
+
+  it("can turn every layer off and back on again", () => {
+    const spec: { mode?: "points" | "density"; layers?: Partial<EmbeddingLayers> } = { mode: "density" };
+    updateLayers(spec, { points: false, density: false, labels: false });
+    expect(spec.layers).toEqual({ points: false, density: false, labels: false });
+    updateLayers(spec, { points: true, density: true, labels: true });
+    expect(spec.layers).toEqual({ points: true, density: true, labels: true });
   });
 });

--- a/packages/viewer/test/embedding_layers.test.ts
+++ b/packages/viewer/test/embedding_layers.test.ts
@@ -1,0 +1,91 @@
+// Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+import { describe, expect, it } from "vitest";
+
+import { effectiveLayers, updateLayers, type EmbeddingLayers } from "../src/charts/embedding/layers.js";
+
+describe("effectiveLayers", () => {
+  it("defaults an empty spec to points and labels without density", () => {
+    const expected: EmbeddingLayers = { points: true, density: false, labels: true };
+    expect(effectiveLayers({})).toEqual(expected);
+  });
+
+  it("treats the legacy points mode the same as an empty spec", () => {
+    expect(effectiveLayers({ mode: "points" })).toEqual({ points: true, density: false, labels: true });
+  });
+
+  it("expands the legacy density mode to points, density, and labels", () => {
+    // Legacy density mode drew points and labels too.
+    expect(effectiveLayers({ mode: "density" })).toEqual({ points: true, density: true, labels: true });
+  });
+
+  it("respects a full layers object verbatim", () => {
+    expect(effectiveLayers({ layers: { points: false, density: true, labels: false } })).toEqual({
+      points: false,
+      density: true,
+      labels: false,
+    });
+  });
+
+  it("merges partial layers over the legacy mode base", () => {
+    expect(effectiveLayers({ mode: "density", layers: { labels: false } })).toEqual({
+      points: true,
+      density: true,
+      labels: false,
+    });
+    expect(effectiveLayers({ mode: "density", layers: { density: false } })).toEqual({
+      points: true,
+      density: false,
+      labels: true,
+    });
+  });
+
+  it("merges partial layers over the default base when mode is absent", () => {
+    expect(effectiveLayers({ layers: { density: true } })).toEqual({ points: true, density: true, labels: true });
+  });
+
+  it("returns a plain JSON-serializable object", () => {
+    const result = effectiveLayers({ mode: "density" });
+    expect(JSON.parse(JSON.stringify(result))).toEqual(result);
+  });
+
+  it("does not alias spec.layers; mutating the result leaves the spec untouched", () => {
+    const spec = { layers: { points: true, density: true, labels: true } };
+    const result = effectiveLayers(spec);
+    result.points = false;
+    result.labels = false;
+    expect(spec.layers).toEqual({ points: true, density: true, labels: true });
+  });
+});
+
+describe("updateLayers", () => {
+  it("replaces a legacy mode with a complete layers object and deletes mode", () => {
+    const spec: { mode?: "points" | "density"; layers?: Partial<EmbeddingLayers> } = { mode: "density" };
+    updateLayers(spec, { points: false });
+    expect(spec.layers).toEqual({ points: false, density: true, labels: true });
+    expect("mode" in spec).toBe(false);
+  });
+
+  it("applies the patch over existing layers and preserves untouched keys", () => {
+    const spec: { layers?: Partial<EmbeddingLayers> } = { layers: { points: false } };
+    updateLayers(spec, { density: true });
+    expect(spec.layers).toEqual({ points: false, density: true, labels: true });
+  });
+
+  it("leaves unrelated spec fields untouched", () => {
+    const data = { table: "items" };
+    const spec: Record<string, any> = { mode: "density", pointSize: 3, data };
+    updateLayers(spec, { labels: false });
+    expect(spec.pointSize).toBe(3);
+    expect(spec.data).toBe(data);
+    expect(Object.keys(spec).sort()).toEqual(["data", "layers", "pointSize"]);
+  });
+
+  it("is idempotent when the same patch is applied twice", () => {
+    const spec: { mode?: "points" | "density"; layers?: Partial<EmbeddingLayers> } = { mode: "density" };
+    updateLayers(spec, { points: false });
+    const first = { ...spec.layers };
+    updateLayers(spec, { points: false });
+    expect(spec.layers).toEqual(first);
+  });
+});


### PR DESCRIPTION
## What this does

Replaces the Points/Density drop-down in the embedding view's Options popup with three independent layer checkboxes — **Points**, **Density**, and **Labels** — like the layer control in mapping tools.

Closes #138.

## Why

The old drop-down was misleading: "Density" still drew points, and once a text column was selected there was no way to turn labels off. Independent toggles make each name honest and unlock the density-only and labels-off views asked for in #138.

## What changed

- The embedding chart's Options popup now has a "Layers" section with Points, Density, and Labels checkboxes; density keeps its threshold slider and its too-many-categories guard (now scoped to just the density row).
- Saved views keep working: the deprecated `mode` spec field is still accepted and renders exactly as before (`"density"` maps to points + density + labels all on). The UI migrates specs to the new `layers` field on first change.
- The component package gains two optional, additive config flags — `showPoints` and `showLabels` — so density-without-points works and labels can be hidden at render time, including labels passed in explicitly, which `autoLabelEnabled` could not hide. The WebGPU renderer now skips the point draw at zero alpha, matching the existing WebGL2 behavior.
- Invalid values in hand-edited specs (null entries, unknown keys) fall back to sensible defaults instead of leaking into the UI.
- 20 new unit tests cover layer resolution, legacy-mode mapping, and the edge cases (`packages/viewer/test/embedding_layers.test.ts`).

## How to see it

1. `npm run dev -w @embedding-atlas/viewer` and load a dataset with x/y columns (plus a text column for labels).
2. In the embedding view, open the ⚙ Options popup → "Layers".
3. Untick Points while Density is on for a clean density-only view; untick Labels to hide labels. Every combination is remembered with the view.
