### PR TITLE
fix: detect plain-bytes image columns

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -6,7 +6,13 @@ export { delay } from "./delay.js";
 export { deepEquals, deepMemo } from "./equals.js";
 export { objectHash, stringHash } from "./hash.js";
 export { interactionHandler, type CursorValue, type DragHandler } from "./interaction_handler.js";
-export { audioToDataUrl, imageToDataUrl } from "./media.js";
+export {
+  audioToDataUrl,
+  detectAudioMimeType,
+  detectBase64MimeType,
+  detectImageMimeType,
+  imageToDataUrl,
+} from "./media.js";
 export { mergeUpdates } from "./merge_updates.js";
 export {
   connectWorker,

--- a/packages/utils/src/media.ts
+++ b/packages/utils/src/media.ts
@@ -89,38 +89,14 @@ export function detectImageMimeType(data: Uint8Array): string | null {
  * extension of `path` when the content is unrecognized. Returns null if
  * neither matches. */
 export function detectAudioMimeType(data: Uint8Array, path?: string): string | null {
-  // Check for MP3
-  if (startsWith(data, [0x49, 0x44, 0x33])) {
-    return "audio/mpeg";
-  }
+  let container = detectAudioContainer(data);
+  if (container != null) return container;
   // Check for MPEG audio / AAC ADTS frames (both share the 0xff sync byte).
   // Top 11 bits = sync word (0xffe0 mask). Layer bits (bits 1-2 of second byte):
   //   00 = AAC (ADTS), non-zero = MPEG audio (MP3/MP2/MP1).
   if (data.length >= 2 && data[0] === 0xff && (data[1] & 0xe0) === 0xe0) {
     const layer = (data[1] >> 1) & 0x03;
     return layer === 0 ? "audio/aac" : "audio/mpeg";
-  }
-  // Check for WAV (RIFF....WAVE)
-  if (startsWith(data, [0x52, 0x49, 0x46, 0x46]) && data.length >= 12) {
-    if (data[8] === 0x57 && data[9] === 0x41 && data[10] === 0x56 && data[11] === 0x45) {
-      return "audio/wav";
-    }
-  }
-  // Check for OGG
-  if (startsWith(data, [0x4f, 0x67, 0x67, 0x53])) {
-    return "audio/ogg";
-  }
-  // Check for FLAC
-  if (startsWith(data, [0x66, 0x4c, 0x61, 0x43])) {
-    return "audio/flac";
-  }
-  // Check for WebM/Matroska (can contain audio)
-  if (startsWith(data, [0x1a, 0x45, 0xdf, 0xa3])) {
-    return "audio/webm";
-  }
-  // Check for M4A/MP4 audio (ftyp box)
-  if (data.length >= 8 && data[4] === 0x66 && data[5] === 0x74 && data[6] === 0x79 && data[7] === 0x70) {
-    return "audio/mp4";
   }
   // Attempt to infering from path extension
   if (path) {
@@ -145,19 +121,66 @@ export function detectAudioMimeType(data: Uint8Array, path?: string): string | n
   return null;
 }
 
+function detectAudioContainer(data: Uint8Array): string | null {
+  // Check for MP3 with an ID3v2 .
+  if (
+    startsWith(data, [0x49, 0x44, 0x33]) &&
+    data.length >= 10 &&
+    (data[3] === 2 || data[3] === 3 || data[3] === 4) &&
+    data[6] < 0x80 &&
+    data[7] < 0x80 &&
+    data[8] < 0x80 &&
+    data[9] < 0x80
+  ) {
+    return "audio/mpeg";
+  }
+  // Check for WAV (RIFF....WAVE)
+  if (startsWith(data, [0x52, 0x49, 0x46, 0x46]) && data.length >= 12) {
+    if (data[8] === 0x57 && data[9] === 0x41 && data[10] === 0x56 && data[11] === 0x45) {
+      return "audio/wav";
+    }
+  }
+  // Check for OGG
+  if (startsWith(data, [0x4f, 0x67, 0x67, 0x53])) {
+    return "audio/ogg";
+  }
+  // Check for FLAC
+  if (startsWith(data, [0x66, 0x4c, 0x61, 0x43])) {
+    return "audio/flac";
+  }
+  // Check for WebM/Matroska
+  if (startsWith(data, [0x1a, 0x45, 0xdf, 0xa3])) {
+    return "audio/webm";
+  }
+  // Check for M4A/MP4 audio
+  // High bytes of 32bit size is 0
+  if (
+    data.length >= 8 &&
+    data[0] === 0 &&
+    data[1] === 0 &&
+    data[2] === 0 &&
+    data[4] === 0x66 &&
+    data[5] === 0x74 &&
+    data[6] === 0x79 &&
+    data[7] === 0x70
+  ) {
+    return "audio/mp4";
+  }
+  return null;
+}
+
+// Real base64-encoded media is far longer,
+// so we omit short base-64 shaped strings entirely
+const MIN_BASE64_DETECT_LENGTH = 64;
+
 /** Detect the MIME type of a raw base64-encoded string (no `data:` prefix) by
- * seeking  magic bytes of its decoded prefix. Returns null if the string
- * is not base64-shaped or the decoded content is unrecognized.*/
+ * sniffing the magic bytes of its decoded prefix. Used to detect
+ * media in string columns. Returns null unless the string is base64-shaped,
+ * at least 64 characters long, and decodes to a multi-byte media signature */
 export function detectBase64MimeType(value: string): string | null {
-  if (!looksLikeBase64(value)) {
-    return null;
-  }
-  try {
-    let bytes = base64DecodePrefix(value);
-    return detectImageMimeType(bytes) ?? detectAudioMimeType(bytes);
-  } catch (_) {
-    return null;
-  }
+  if (value.length < MIN_BASE64_DETECT_LENGTH || !looksLikeBase64(value)) return null;
+  let bytes = base64DecodePrefix(value);
+  return detectImageMimeType(bytes) ?? detectAudioContainer(bytes);
 }
 
 const BASE64_SHAPE = /^[A-Za-z0-9+/]+={0,2}$/;

--- a/packages/utils/src/media.ts
+++ b/packages/utils/src/media.ts
@@ -1,14 +1,14 @@
 // Copyright (c) 2025 Apple Inc. Licensed under MIT License.
 
 export function imageToDataUrl(value: any): string | null {
-  return mediaToDataUrl(value, detectImageType);
+  return mediaToDataUrl(value, detectImageMimeType);
 }
 
 export function audioToDataUrl(value: any): string | null {
-  return mediaToDataUrl(value, detectAudioType);
+  return mediaToDataUrl(value, detectAudioMimeType);
 }
 
-function mediaToDataUrl(value: any, detectType: (bytes: Uint8Array, path?: string) => string): string | null {
+function mediaToDataUrl(value: any, detectType: (bytes: Uint8Array, path?: string) => string | null): string | null {
   if (value == null) {
     return null;
   }
@@ -16,9 +16,11 @@ function mediaToDataUrl(value: any, detectType: (bytes: Uint8Array, path?: strin
     if (typeof value == "string") {
       if (value.startsWith("data:") || value.startsWith("http://") || value.startsWith("https://")) {
         return value;
-      } else {
-        let type = detectType(base64Decode(value));
+      } else if (looksLikeBase64(value)) {
+        let type = detectType(base64DecodePrefix(value)) ?? "application/octet-stream";
         return `data:${type};base64,` + value;
+      } else {
+        return null;
       }
     } else {
       let bytes: Uint8Array<ArrayBuffer> | null = null;
@@ -33,7 +35,7 @@ function mediaToDataUrl(value: any, detectType: (bytes: Uint8Array, path?: strin
         bytes = value as any;
       }
       if (bytes != null) {
-        let type = detectType(bytes, path);
+        let type = detectType(bytes, path) ?? "application/octet-stream";
         return `data:${type};base64,` + base64Encode(bytes);
       }
     }
@@ -55,14 +57,24 @@ function startsWith(data: Uint8Array, prefix: number[]): boolean {
   return true;
 }
 
-function detectImageType(data: Uint8Array): string {
+/** Detect the image MIME type from magic bytes. Returns null for unrecognized data. */
+export function detectImageMimeType(data: Uint8Array): string | null {
   if (startsWith(data, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) {
     return "image/png";
   } else if (startsWith(data, [0xff, 0xd8, 0xff])) {
     return "image/jpeg";
   } else if (startsWith(data, [0x49, 0x49, 0x2a, 0x00])) {
     return "image/tiff";
-  } else if (startsWith(data, [0x42, 0x4d])) {
+  } else if (
+    // Require the header's reserved
+    // bytes (offset 6-9) to be zero so arbitrary binary doesn't misdetect.
+    startsWith(data, [0x42, 0x4d]) &&
+    data.length >= 10 &&
+    data[6] === 0 &&
+    data[7] === 0 &&
+    data[8] === 0 &&
+    data[9] === 0
+  ) {
     return "image/bmp";
   } else if (
     startsWith(data, [0x47, 0x49, 0x46, 0x38, 0x37, 0x61]) ||
@@ -70,12 +82,14 @@ function detectImageType(data: Uint8Array): string {
   ) {
     return "image/gif";
   }
-  // Unknown, fallback to generic type
-  return "application/octet-stream";
+  return null;
 }
 
-function detectAudioType(data: Uint8Array, path?: string): string {
-  // Check for MP3 (ID3 tag)
+/** Detect the audio MIME type from magic bytes, falling back to the file
+ * extension of `path` when the content is unrecognized. Returns null if
+ * neither matches. */
+export function detectAudioMimeType(data: Uint8Array, path?: string): string | null {
+  // Check for MP3
   if (startsWith(data, [0x49, 0x44, 0x33])) {
     return "audio/mpeg";
   }
@@ -108,7 +122,7 @@ function detectAudioType(data: Uint8Array, path?: string): string {
   if (data.length >= 8 && data[4] === 0x66 && data[5] === 0x74 && data[6] === 0x79 && data[7] === 0x70) {
     return "audio/mp4";
   }
-  // Fallback: try to infer from path extension
+  // Attempt to infering from path extension
   if (path) {
     const ext = path.split(".").pop()?.toLowerCase();
     switch (ext) {
@@ -128,19 +142,46 @@ function detectAudioType(data: Uint8Array, path?: string): string {
         return "audio/webm";
     }
   }
-  // Unknown, fallback to generic type
-  return "application/octet-stream";
+  return null;
+}
+
+/** Detect the MIME type of a raw base64-encoded string (no `data:` prefix) by
+ * seeking  magic bytes of its decoded prefix. Returns null if the string
+ * is not base64-shaped or the decoded content is unrecognized.*/
+export function detectBase64MimeType(value: string): string | null {
+  if (!looksLikeBase64(value)) {
+    return null;
+  }
+  try {
+    let bytes = base64DecodePrefix(value);
+    return detectImageMimeType(bytes) ?? detectAudioMimeType(bytes);
+  } catch (_) {
+    return null;
+  }
+}
+
+const BASE64_SHAPE = /^[A-Za-z0-9+/]+={0,2}$/;
+
+function looksLikeBase64(value: string): boolean {
+  return value.length >= 8 && value.length % 4 != 1 && BASE64_SHAPE.test(value);
+}
+
+/** Decode only the first few bytes of a base64 string — enough for magic-byte
+ * sniffing without materializing multi-megabyte payloads. */
+function base64DecodePrefix(base64: string): Uint8Array {
+  const binaryString = atob(base64.length > 32 ? base64.slice(0, 32) : base64);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes;
 }
 
 function base64Encode(data: Uint8Array): string {
+  const chunkSize = 0x8000; // 32kb chunk
   let binary = "";
-  for (let i = 0; i < data.length; i++) {
-    binary += String.fromCharCode(data[i]);
+  for (let i = 0; i < data.length; i += chunkSize) {
+    binary += String.fromCharCode(...data.subarray(i, i + chunkSize));
   }
   return btoa(binary);
-}
-
-function base64Decode(base64: string): Uint8Array {
-  const binaryString = atob(base64);
-  return new Uint8Array([...binaryString].map((char) => char.charCodeAt(0)));
 }

--- a/packages/utils/test/media.test.js
+++ b/packages/utils/test/media.test.js
@@ -1,0 +1,162 @@
+// Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+import {
+  audioToDataUrl,
+  detectAudioMimeType,
+  detectBase64MimeType,
+  detectImageMimeType,
+  imageToDataUrl,
+} from "@embedding-atlas/utils";
+
+import { describe, expect, it } from "vitest";
+
+const PNG_HEADER = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d];
+const JPEG_HEADER = [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46];
+const GIF89_HEADER = [0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00];
+const TIFF_LE_HEADER = [0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00];
+const BMP_HEADER = [0x42, 0x4d, 0x9a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7a, 0x00];
+const WAV_HEADER = [0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45];
+const ID3_HEADER = [0x49, 0x44, 0x33, 0x03, 0x00, 0x00, 0x00, 0x00, 0x07, 0x76];
+const MP3_SYNC_HEADER = [0xff, 0xfb, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00];
+const AAC_ADTS_HEADER = [0xff, 0xf1, 0x50, 0x80, 0x00, 0x00, 0x00, 0x00];
+const OGG_HEADER = [0x4f, 0x67, 0x67, 0x53, 0x00, 0x02, 0x00, 0x00];
+const FLAC_HEADER = [0x66, 0x4c, 0x61, 0x43, 0x00, 0x00, 0x00, 0x22];
+const M4A_HEADER = [0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70];
+const UNKNOWN_BYTES = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+
+function bytes(values) {
+  return new Uint8Array(values);
+}
+
+function base64(values) {
+  return btoa(String.fromCharCode(...values));
+}
+
+function padded(values, length = 48) {
+  return values.concat(new Array(length - values.length).fill(0));
+}
+
+describe("detectImageMimeType", () => {
+  it("detects known image formats from magic bytes", () => {
+    expect(detectImageMimeType(bytes(PNG_HEADER))).toBe("image/png");
+    expect(detectImageMimeType(bytes(JPEG_HEADER))).toBe("image/jpeg");
+    expect(detectImageMimeType(bytes(GIF89_HEADER))).toBe("image/gif");
+    expect(detectImageMimeType(bytes(TIFF_LE_HEADER))).toBe("image/tiff");
+    expect(detectImageMimeType(bytes(BMP_HEADER))).toBe("image/bmp");
+  });
+
+  it("returns null for unrecognized data", () => {
+    expect(detectImageMimeType(bytes(UNKNOWN_BYTES))).toBeNull();
+    expect(detectImageMimeType(bytes([]))).toBeNull();
+    expect(detectImageMimeType(bytes(WAV_HEADER))).toBeNull();
+  });
+
+  it("rejects 'BM' data whose header bytes are not zero", () => {
+    expect(detectImageMimeType(bytes([0x42, 0x4d, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]))).toBeNull();
+  });
+});
+
+describe("detectAudioMimeType", () => {
+  it("detects known audio formats from magic bytes", () => {
+    expect(detectAudioMimeType(bytes(WAV_HEADER))).toBe("audio/wav");
+    expect(detectAudioMimeType(bytes(ID3_HEADER))).toBe("audio/mpeg");
+    expect(detectAudioMimeType(bytes(MP3_SYNC_HEADER))).toBe("audio/mpeg");
+    expect(detectAudioMimeType(bytes(AAC_ADTS_HEADER))).toBe("audio/aac");
+    expect(detectAudioMimeType(bytes(OGG_HEADER))).toBe("audio/ogg");
+    expect(detectAudioMimeType(bytes(FLAC_HEADER))).toBe("audio/flac");
+    expect(detectAudioMimeType(bytes(M4A_HEADER))).toBe("audio/mp4");
+  });
+
+  it("falls back to the  extensions for unrecognized", () => {
+    expect(detectAudioMimeType(bytes(UNKNOWN_BYTES), "clip.mp3")).toBe("audio/mpeg");
+    expect(detectAudioMimeType(bytes(UNKNOWN_BYTES), "clip.wav")).toBe("audio/wav");
+  });
+});
+
+describe("detectBase64MimeType", () => {
+  it("detects media in base64-encoded strings", () => {
+    expect(detectBase64MimeType(base64(padded(PNG_HEADER)))).toBe("image/png");
+    expect(detectBase64MimeType(base64(padded(JPEG_HEADER)))).toBe("image/jpeg");
+    expect(detectBase64MimeType(base64(padded(WAV_HEADER)))).toBe("audio/wav");
+    expect(detectBase64MimeType(base64(padded(ID3_HEADER)))).toBe("audio/mpeg");
+  });
+
+  it("returns null for non-base64 strings", () => {
+    expect(detectBase64MimeType("hello, world!")).toBeNull();
+    expect(detectBase64MimeType("short")).toBeNull();
+    expect(detectBase64MimeType("")).toBeNull();
+    expect(detectBase64MimeType("data:image/png;base64,abcd")).toBeNull();
+  });
+
+  it("returns null for strings very short to be real media", () => {
+    expect(detectBase64MimeType(base64(PNG_HEADER))).toBeNull();
+    expect(detectBase64MimeType(base64(WAV_HEADER))).toBeNull();
+  });
+
+  it("returns null for base64-shaped strings with unrecognized content", () => {
+    // For eg. hex hashes are valid base64 characters but they must never decode to media magic bytes.
+    expect(detectBase64MimeType("d2d2f1a4b8c09e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f")).toBeNull();
+    expect(detectBase64MimeType(base64(padded(UNKNOWN_BYTES)))).toBeNull();
+  });
+
+  it("does not misdetect base64-shaped text as audio", () => {
+    expect(detectBase64MimeType("//foobar")).toBeNull();
+    expect(detectBase64MimeType("//TODOxx")).toBeNull();
+    expect(detectBase64MimeType("SUQzTEST")).toBeNull();
+    expect(detectBase64MimeType("/".repeat(64))).toBeNull();
+    expect(detectBase64MimeType(base64(padded(MP3_SYNC_HEADER)))).toBeNull();
+    expect(detectBase64MimeType("SUQz" + "A".repeat(60))).toBeNull();
+  });
+});
+
+describe("imageToDataUrl", () => {
+  it("converts a bare Uint8Array", () => {
+    expect(imageToDataUrl(bytes(PNG_HEADER))).toBe("data:image/png;base64," + base64(PNG_HEADER));
+  });
+
+  it("converts a {bytes, path} object", () => {
+    expect(imageToDataUrl({ bytes: bytes(JPEG_HEADER), path: "photo.jpg" })).toBe(
+      "data:image/jpeg;base64," + base64(JPEG_HEADER),
+    );
+  });
+
+  it("converts a {bytes} object without a path", () => {
+    expect(imageToDataUrl({ bytes: bytes(PNG_HEADER), path: null })).toBe(
+      "data:image/png;base64," + base64(PNG_HEADER),
+    );
+  });
+
+  it("passes through data: and http URLs", () => {
+    expect(imageToDataUrl("data:image/png;base64,abcd")).toBe("data:image/png;base64,abcd");
+    expect(imageToDataUrl("https://example.com/a.png")).toBe("https://example.com/a.png");
+    expect(imageToDataUrl("http://example.com/a.png")).toBe("http://example.com/a.png");
+  });
+
+  it("wraps a raw base64 string with a sniffed MIME type", () => {
+    let value = base64(PNG_HEADER);
+    expect(imageToDataUrl(value)).toBe("data:image/png;base64," + value);
+  });
+
+  it("labels unrecognized binary as application/octet-stream", () => {
+    expect(imageToDataUrl(bytes(UNKNOWN_BYTES))).toBe("data:application/octet-stream;base64," + base64(UNKNOWN_BYTES));
+  });
+
+  it("returns null for non-media strings and null values", () => {
+    expect(imageToDataUrl("not base64 at all!")).toBeNull();
+    expect(imageToDataUrl(null)).toBeNull();
+    expect(imageToDataUrl(undefined)).toBeNull();
+    expect(imageToDataUrl(42)).toBeNull();
+  });
+});
+
+describe("audioToDataUrl", () => {
+  it("converts audio bytes", () => {
+    expect(audioToDataUrl(bytes(WAV_HEADER))).toBe("data:audio/wav;base64," + base64(WAV_HEADER));
+  });
+
+  it("uses the path extension for unrecognized data", () => {
+    expect(audioToDataUrl({ bytes: bytes(UNKNOWN_BYTES), path: "clip.mp3" })).toBe(
+      "data:audio/mpeg;base64," + base64(UNKNOWN_BYTES),
+    );
+  });
+});

--- a/packages/viewer/src/renderers/renderer_utils.ts
+++ b/packages/viewer/src/renderers/renderer_utils.ts
@@ -1,10 +1,14 @@
 // Copyright (c) 2025 Apple Inc. Licensed under MIT License.
 
+import { detectAudioMimeType, detectBase64MimeType, detectImageMimeType } from "@embedding-atlas/utils";
+
 const imageExtensions = new Set(["png", "jpg", "jpeg", "tiff", "tif", "gif"]);
 const audioExtensions = new Set(["wav", "wave", "mp3", "aac"]);
 
-// Quick heuristic check based on string prefixes and file extensions.
-// May not capture all formats (e.g., raw base64 strings, binary objects without a path).
+/** Detect displayable media from a column value. Strings are checked by prefix
+ * (URLs, data: URLs) and then probed as raw base64; binary values are detected based
+ * on magic bytes, with a fallback on the path's
+ * file extension. */
 export function valueKind(value: any): "link" | "image" | "audio" | undefined {
   if (typeof value == "string") {
     if (value.startsWith("http://") || value.startsWith("https://")) {
@@ -14,18 +18,55 @@ export function valueKind(value: any): "link" | "image" | "audio" | undefined {
     } else if (value.startsWith("data:audio/")) {
       return "audio";
     }
-  } else if (typeof value == "object" && value != null && value.bytes) {
-    if (typeof value.path == "string") {
-      let ext = value.path.split(".").pop()?.toLowerCase();
-      if (imageExtensions.has(ext)) {
+    let mimeType = detectBase64MimeType(value);
+    if (mimeType != null) {
+      if (mimeType.startsWith("image/")) {
         return "image";
-      } else if (audioExtensions.has(ext)) {
+      } else if (mimeType.startsWith("audio/")) {
         return "audio";
       }
+    }
+    return undefined;
+  }
+
+  let bytes: Uint8Array | null = null;
+  let path: string | undefined = undefined;
+  if (value instanceof Uint8Array) {
+    bytes = value;
+  } else if (typeof value == "object" && value != null && value.bytes) {
+    if (value.bytes instanceof Uint8Array) {
+      bytes = value.bytes;
+    }
+    if (typeof value.path == "string") {
+      path = value.path;
+    }
+  }
+
+  if (bytes != null) {
+    if (detectImageMimeType(bytes) != null) {
+      return "image";
+    }
+    if (detectAudioMimeType(bytes) != null) {
+      return "audio";
+    }
+  }
+  if (path != null) {
+    let ext = path.split(".").pop()?.toLowerCase() ?? "";
+    if (imageExtensions.has(ext)) {
+      return "image";
+    } else if (audioExtensions.has(ext)) {
+      return "audio";
     }
   }
   return undefined;
 }
+
+/**
+ * Prevents large binary values from being expanded into a JSON array of numbers.
+ * For eg. this is enough to keep typical embedding vectors visible and  small enough that an
+ * undetected image can never dump megabytes of digits into the DOM. */
+
+const MAX_INLINE_BINARY_BYTES = 16384;
 
 export function safeJSONStringify(value: any, space?: number): string {
   try {
@@ -33,6 +74,9 @@ export function safeJSONStringify(value: any, space?: number): string {
       value,
       (_, value) => {
         if (value instanceof Object && ArrayBuffer.isView(value)) {
+          if (value.byteLength > MAX_INLINE_BINARY_BYTES) {
+            return `(${value.constructor.name}, ${formatByteSize(value.byteLength)})`;
+          }
           return Array.from(value as any);
         }
         return value;
@@ -41,6 +85,16 @@ export function safeJSONStringify(value: any, space?: number): string {
     );
   } catch (e) {
     return "(invalid)";
+  }
+}
+
+function formatByteSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  } else if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} kB`;
+  } else {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   }
 }
 

--- a/packages/viewer/test/renderer_utils.test.ts
+++ b/packages/viewer/test/renderer_utils.test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+import { describe, expect, it } from "vitest";
+
+import { safeJSONStringify, valueKind } from "../src/renderers/renderer_utils.js";
+
+const PNG_HEADER = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d];
+const WAV_HEADER = [0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45];
+const UNKNOWN_BYTES = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+
+function bytes(values: number[]): Uint8Array {
+  return new Uint8Array(values);
+}
+
+function base64(values: number[]): string {
+  return btoa(String.fromCharCode(...values));
+}
+
+function padded(values: number[], length: number = 48): number[] {
+  return values.concat(new Array(length - values.length).fill(0));
+}
+
+describe("valueKind", () => {
+  it("detects links and data URLs from string prefixes", () => {
+    expect(valueKind("https://example.com/a.png")).toBe("link");
+    expect(valueKind("http://example.com")).toBe("link");
+    expect(valueKind("data:image/png;base64,abcd")).toBe("image");
+    expect(valueKind("data:audio/wav;base64,abcd")).toBe("audio");
+  });
+
+  it("detects raw base64-encoded media strings", () => {
+    expect(valueKind(base64(padded(PNG_HEADER)))).toBe("image");
+    expect(valueKind(base64(padded(WAV_HEADER)))).toBe("audio");
+  });
+
+  it("does not misdetect ordinary strings", () => {
+    expect(valueKind("hello, world")).toBeUndefined();
+    expect(valueKind("")).toBeUndefined();
+    expect(valueKind("//foobar")).toBeUndefined();
+    expect(valueKind("//TODOxx")).toBeUndefined();
+    expect(valueKind("SUQzTEST")).toBeUndefined();
+    expect(valueKind("d2d2f1a4b8c09e7f6a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f")).toBeUndefined();
+    expect(valueKind(base64(padded(UNKNOWN_BYTES)))).toBeUndefined();
+    expect(valueKind(base64(PNG_HEADER))).toBeUndefined();
+  });
+
+  it("detects a bare Uint8Array by magic bytes", () => {
+    expect(valueKind(bytes(PNG_HEADER))).toBe("image");
+    expect(valueKind(bytes(WAV_HEADER))).toBe("audio");
+    expect(valueKind(bytes(UNKNOWN_BYTES))).toBeUndefined();
+  });
+
+  it("detects a {bytes} struct without a path", () => {
+    expect(valueKind({ bytes: bytes(PNG_HEADER), path: null })).toBe("image");
+    expect(valueKind({ bytes: bytes(PNG_HEADER) })).toBe("image");
+    expect(valueKind({ bytes: bytes(WAV_HEADER) })).toBe("audio");
+  });
+
+  it("falls back to the path extension when magic bytes are not recognized", () => {
+    expect(valueKind({ bytes: bytes(UNKNOWN_BYTES), path: "scan.tif" })).toBe("image");
+    expect(valueKind({ bytes: bytes(UNKNOWN_BYTES), path: "clip.wav" })).toBe("audio");
+    expect(valueKind({ bytes: bytes(UNKNOWN_BYTES), path: "notes.txt" })).toBeUndefined();
+  });
+
+  it("returns undefined for non-media values", () => {
+    expect(valueKind(null)).toBeUndefined();
+    expect(valueKind(undefined)).toBeUndefined();
+    expect(valueKind(42)).toBeUndefined();
+    expect(valueKind({ a: 1 })).toBeUndefined();
+    expect(valueKind([1, 2, 3])).toBeUndefined();
+  });
+});
+
+describe("safeJSONStringify", () => {
+  it("inlines small binary values as number arrays", () => {
+    expect(safeJSONStringify(new Uint8Array([1, 2, 3]))).toBe("[1,2,3]");
+    expect(safeJSONStringify({ bytes: new Uint8Array([1, 2]), path: "a.bin" })).toBe('{"bytes":[1,2],"path":"a.bin"}');
+  });
+
+  it("keeps embedding vectors like data visible", () => {
+    let vector = new Float32Array(384);
+    let result = safeJSONStringify(vector);
+    expect(result.startsWith("[")).toBe(true);
+    expect(JSON.parse(result).length).toBe(384);
+  });
+});


### PR DESCRIPTION
### Problem
Media detection is strictly narrower than media rendering. A bare binary column or a Hugging Face-style `{bytes, path: null}` struct faults through to `safeJSONStringify`, which expands the bytes into a huge JSON array of of integers in table cells and tooltips

### Fix

Detect MIME types based on Magic Bytes. Check magic bytes on bare `Uint8Array` values, on `{bytes}` structs with or without a path (for eg. HF datasets frequently have path: None). Further, base64 strings also checked by decoding a 24-byte prefix instead of materializing the entire multi-MB payload, and encoding uses 32 kB chunks instead of one string concatenation per byte. Extension check kept as a fallback.