### PR TITLE
fix: false-positive full-text search matches (#137)

### DIFF
--- a/packages/viewer/src/search/search-index.ts
+++ b/packages/viewer/src/search/search-index.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+import { Charset, Index, type IndexOptions } from "flexsearch";
+
+const options: IndexOptions = {
+  tokenize: "forward",
+  // LatinDefault performs case-folding and diacritic normalization without
+  // phonetic merging. The fuzzier presets (LatinBalance/Advanced/Extra/Soundex)
+  // collapse unrelated words that share a prefix and similar-sounding letters
+  // (e.g. "aldi" and "aldea") into false-positive matches.
+  encoder: Charset.LatinDefault,
+};
+
+export class SearchIndex {
+  private index: Index;
+
+  constructor() {
+    this.index = new Index(options);
+  }
+
+  clear() {
+    this.index.clear();
+    this.index.cleanup();
+    this.index = new Index(options);
+  }
+
+  addPoints(points: { id: string | number; text: string }[]) {
+    for (let p of points) {
+      this.index.add(p.id, p.text);
+    }
+  }
+
+  query(query: string, limit: number): (string | number)[] {
+    return this.index.search(query, { limit });
+  }
+}

--- a/packages/viewer/src/search/search.worker.ts
+++ b/packages/viewer/src/search/search.worker.ts
@@ -1,40 +1,12 @@
 // Copyright (c) 2025 Apple Inc. Licensed under MIT License.
 
 import { createWorkerRuntime } from "@embedding-atlas/utils";
-import { Charset, Index, type IndexOptions } from "flexsearch";
+
+import { SearchIndex } from "./search-index.js";
 
 let { handler, registerClass } = createWorkerRuntime();
 
 onmessage = handler;
-
-const options: IndexOptions = {
-  tokenize: "forward",
-  encoder: Charset.LatinBalance,
-};
-
-class SearchIndex {
-  private index: Index;
-
-  constructor() {
-    this.index = new Index(options);
-  }
-
-  clear() {
-    this.index.clear();
-    this.index.cleanup();
-    this.index = new Index(options);
-  }
-
-  addPoints(points: { id: string | number; text: string }[]) {
-    for (let p of points) {
-      this.index.add(p.id, p.text);
-    }
-  }
-
-  query(query: string, limit: number): (string | number)[] {
-    return this.index.search(query, { limit });
-  }
-}
 
 export type { SearchIndex };
 

--- a/packages/viewer/test/search_index.test.ts
+++ b/packages/viewer/test/search_index.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { SearchIndex } from "../src/search/search-index.js";
+
+describe("SearchIndex", () => {
+  let index: SearchIndex;
+
+  beforeEach(() => {
+    index = new SearchIndex();
+    index.addPoints([
+      { id: 1, text: "ALDI" },
+      { id: 2, text: "ALDEA HOMES" },
+      { id: 3, text: "ALDI Grocery Store" },
+      { id: 4, text: "Aldente Pasta Bar" },
+      { id: 5, text: "Trader Joe's" },
+      { id: 6, text: "Café Restaurant" },
+      { id: 7, text: "Walgreens Pharmacy" },
+    ]);
+  });
+
+  it("matches an exact substring", () => {
+    const results = index.query("aldi", 10);
+    expect(results).toContain(1);
+    expect(results).toContain(3);
+  });
+
+  it("does not return unrelated words that merely share a prefix (regression for #137)", () => {
+    const results = index.query("aldi", 10);
+    expect(results).not.toContain(2); // "ALDEA HOMES"
+    expect(results).not.toContain(4); // "Aldente Pasta Bar"
+  });
+
+  it("is case-insensitive", () => {
+    const results = index.query("ALDI", 10);
+    expect(results).toContain(1);
+  });
+
+  it("still tolerates prefix queries (forward tokenization preserved)", () => {
+    const results = index.query("walgreen", 10);
+    expect(results).toContain(7);
+  });
+
+  it("still normalizes diacritics", () => {
+    const results = index.query("cafe", 10);
+    expect(results).toContain(6);
+  });
+
+  it("returns an empty array for queries with no match", () => {
+    const results = index.query("zzzzzz", 10);
+    expect(results).toEqual([]);
+  });
+
+  it("respects the limit parameter", () => {
+    const results = index.query("aldi", 1);
+    expect(results.length).toBe(1);
+  });
+
+  it("clear() removes previously indexed points", () => {
+    index.clear();
+    index.addPoints([{ id: 100, text: "Only This" }]);
+    expect(index.query("aldi", 10)).toEqual([]);
+    expect(index.query("only", 10)).toContain(100);
+  });
+});


### PR DESCRIPTION
Fixes #137. Switches the flexsearch encoder from `LatinBalance` to `LatinDefault` — the phonetic normalization in LatinBalance was collapsing unrelated words that share a prefix (e.g. "aldi" matching "ALDEA HOMES"). Also extracted the pure index logic out of `search.worker.ts` into `search-index.ts` so it's unit-testable without a worker runtime, and added regression tests.