### PR TITLE
Add onLabelsChange callback for cluster labels

### DIFF
--- a/packages/component/src/lib/embedding_view/EmbeddingView.svelte
+++ b/packages/component/src/lib/embedding_view/EmbeddingView.svelte
@@ -26,6 +26,7 @@
     onTooltip = null,
     onSelection = null,
     onRangeSelection = null,
+    onLabelsChange = null,
     cache = null,
   }: EmbeddingViewProps = $props();
 
@@ -94,5 +95,6 @@
   onViewportState={onViewportState}
   rangeSelection={rangeSelection}
   onRangeSelection={onRangeSelection}
+  onLabelsChange={onLabelsChange}
   cache={cache}
 />

--- a/packages/component/src/lib/embedding_view/EmbeddingViewImpl.svelte
+++ b/packages/component/src/lib/embedding_view/EmbeddingViewImpl.svelte
@@ -29,6 +29,7 @@
     onTooltip: ((value: Selection | null) => void) | null;
     onSelection: ((value: Selection[] | null) => void) | null;
     onRangeSelection: ((value: Rectangle | Point[] | null) => void) | null;
+    onLabelsChange: ((labels: LabelWithBounds[]) => void) | null;
     cache: Cache | null;
     cacheIdentifier?: any | null;
   }
@@ -109,7 +110,7 @@
   import { layoutLabels, type LabelWithPlacement } from "./labels.js";
   import { simplifyPolygon } from "./simplify_polygon.js";
   import { resolveTheme, type ThemeConfig } from "./theme.js";
-  import type { Cache, CustomComponent, Label, LabelContent, OverlayProxy } from "./types.js";
+  import type { Cache, CustomComponent, Label, LabelContent, LabelWithBounds, OverlayProxy } from "./types.js";
   import { findClusters } from "./worker/index.js";
 
   interface SelectionBase {
@@ -146,6 +147,7 @@
     onTooltip = null,
     onSelection = null,
     onRangeSelection = null,
+    onLabelsChange = null,
     cache = null,
     cacheIdentifier = undefined,
   }: Props<Selection> = $props();
@@ -199,6 +201,16 @@
     }
     rangeSelection = newValue;
     onRangeSelection?.(newValue);
+  }
+
+  let lastEmittedLabels: LabelWithBounds[] | null = null;
+
+  function emitLabelsChange(next: LabelWithBounds[]) {
+    if (deepEquals(lastEmittedLabels, next)) {
+      return;
+    }
+    lastEmittedLabels = next;
+    onLabelsChange?.(next);
   }
 
   let clusterLabels: LabelWithPlacement[] = $state([]);
@@ -578,7 +590,7 @@
     return collectedClusters.filter((x) => x.sumDensity / maxDensity > densityThreshold);
   }
 
-  async function generateLabels(viewport: ViewportState): Promise<Label[]> {
+  async function generateLabels(viewport: ViewportState): Promise<LabelWithBounds[]> {
     if (renderer == null || queryClusterLabels == null) {
       return [];
     }
@@ -615,14 +627,16 @@
       }
     }
 
-    let result: Label[] = newClusters
+    let result: LabelWithBounds[] = newClusters
       .filter((x) => x.content != null && (typeof x.content !== "string" || x.content.length > 0))
-      .map((x) => ({
+      .map((x, i) => ({
+        id: `cluster-${x.bandwidth}-${i}-${x.x.toFixed(4)}-${x.y.toFixed(4)}`,
         x: x.x,
         y: x.y,
         content: x.content!,
         priority: x.sumDensity,
         level: x.bandwidth == 10 ? 0 : 1,
+        rects: x.rects,
       }));
 
     if (cache != null) {
@@ -639,11 +653,18 @@
     }
     if (labels != null) {
       clusterLabels = await layoutLabels(vp.scale(), labels, resolvedTheme.fontFamily);
+      emitLabelsChange(
+        labels.map((label, i) => ({
+          ...label,
+          id: `label-${i}-${label.x.toFixed(4)}-${label.y.toFixed(4)}`,
+        })),
+      );
     } else {
       statusMessage = "Generating labels...";
       try {
         let result = await generateLabels(viewport);
         clusterLabels = await layoutLabels(vp.scale(), result, resolvedTheme.fontFamily);
+        emitLabelsChange(result);
       } catch (e) {
         console.error("Error while generating labels", e);
       } finally {

--- a/packages/component/src/lib/embedding_view/EmbeddingViewMosaic.svelte
+++ b/packages/component/src/lib/embedding_view/EmbeddingViewMosaic.svelte
@@ -55,6 +55,7 @@
     onTooltip = null,
     onSelection = null,
     onRangeSelection = null,
+    onLabelsChange = null,
     cache = null,
   }: EmbeddingViewMosaicProps = $props();
 
@@ -513,6 +514,7 @@
     effectiveRangeSelection = v;
     onRangeSelection?.(v);
   }}
+  onLabelsChange={onLabelsChange}
   cache={cache}
   cacheIdentifier={{ table, x, y, text }}
 />

--- a/packages/component/src/lib/embedding_view/embedding_view_api.ts
+++ b/packages/component/src/lib/embedding_view/embedding_view_api.ts
@@ -7,7 +7,7 @@ import Component from "./EmbeddingView.svelte";
 import type { Point, Rectangle, ViewportState } from "../utils.js";
 import type { EmbeddingViewConfig } from "./embedding_view_config.js";
 import type { ThemeConfig } from "./theme.js";
-import type { Cache, CustomComponent, DataPoint, Label, LabelContent, OverlayProxy } from "./types.js";
+import type { Cache, CustomComponent, DataPoint, Label, LabelContent, LabelWithBounds, OverlayProxy } from "./types.js";
 
 export interface EmbeddingViewProps {
   /** The data. */
@@ -78,6 +78,11 @@ export interface EmbeddingViewProps {
 
   /** A callback for when `rangeSelection` changes. */
   onRangeSelection?: ((value: Rectangle | Point[] | null) => void) | null;
+
+  /** A callback when generated or provided cluster labels change.
+   *  Fires after label recomputation when the label set materially changes
+   *  (not on every pan/zoom). Labels include data-coordinate cluster bounds when available. */
+  onLabelsChange?: ((labels: LabelWithBounds[]) => void) | null;
 
   /** An async function that returns a data point near the given (x, y) location.
    *  The `unitDistance` parameter is the distance of a single pixel in data domain.

--- a/packages/component/src/lib/embedding_view/embedding_view_mosaic_api.ts
+++ b/packages/component/src/lib/embedding_view/embedding_view_mosaic_api.ts
@@ -8,7 +8,16 @@ import Component from "./EmbeddingViewMosaic.svelte";
 import type { Point, Rectangle, ViewportState } from "../utils.js";
 import type { EmbeddingViewConfig } from "./embedding_view_config.js";
 import type { ThemeConfig } from "./theme.js";
-import type { Cache, CustomComponent, DataField, DataPoint, DataPointID, Label, OverlayProxy } from "./types.js";
+import type {
+  Cache,
+  CustomComponent,
+  DataField,
+  DataPoint,
+  DataPointID,
+  Label,
+  LabelWithBounds,
+  OverlayProxy,
+} from "./types.js";
 
 export interface EmbeddingViewMosaicProps {
   /** The Mosaic coordinator.
@@ -123,6 +132,11 @@ export interface EmbeddingViewMosaicProps {
 
   /** A callback for when `rangeSelection` changes. */
   onRangeSelection?: ((value: Rectangle | Point[] | null) => void) | null;
+
+  /** A callback when generated or provided cluster labels change.
+   *  Fires after label recomputation when the label set materially changes
+   *  (not on every pan/zoom). Labels include data-coordinate cluster bounds when available. */
+  onLabelsChange?: ((labels: LabelWithBounds[]) => void) | null;
 
   /** A custom renderer to draw the tooltip content. */
   customTooltip?: CustomComponent<HTMLDivElement, { tooltip: DataPoint }> | null;

--- a/packages/component/src/lib/embedding_view/types.ts
+++ b/packages/component/src/lib/embedding_view/types.ts
@@ -1,5 +1,7 @@
 // Copyright (c) 2025 Apple Inc. Licensed under MIT License.
 
+import type { Rectangle } from "../utils.js";
+
 export type DataPointID = string | number | bigint;
 
 export interface DataPoint {
@@ -32,6 +34,14 @@ export interface Label {
   level?: number | null;
   /** Placement priority. */
   priority?: number | null;
+}
+
+/** A generated cluster label with optional stable id and data-space region bounds. */
+export interface LabelWithBounds extends Label {
+  /** Stable id for this label within the current generation. */
+  id?: string;
+  /** Bounding rectangles in data coordinates covering the cluster region. */
+  rects?: Rectangle[];
 }
 
 export interface OverlayProxy {

--- a/packages/component/src/lib/index.ts
+++ b/packages/component/src/lib/index.ts
@@ -19,6 +19,7 @@ export type {
   DataPointID,
   Label,
   LabelContent,
+  LabelWithBounds,
   OverlayProxy,
 } from "./embedding_view/types.js";
 export type { Point, Rectangle, ViewportState } from "./utils.js";

--- a/packages/viewer/src/EmbeddingAtlas.svelte
+++ b/packages/viewer/src/EmbeddingAtlas.svelte
@@ -36,6 +36,7 @@
     onExportSelection,
     onStateChange,
     onPredicateChange,
+    onLabelsChange,
     modelContext,
     cache,
   }: EmbeddingAtlasProps = $props();
@@ -55,6 +56,7 @@
     onExportSelection,
     onStateChange,
     onPredicateChange,
+    onLabelsChange,
     modelContext,
     cache,
   });

--- a/packages/viewer/src/api.ts
+++ b/packages/viewer/src/api.ts
@@ -2,7 +2,7 @@
 
 // The component API for embedding viewer.
 
-import type { EmbeddingViewConfig, Label } from "@embedding-atlas/component";
+import type { EmbeddingViewConfig, Label, LabelWithBounds } from "@embedding-atlas/component";
 import type { Coordinator } from "@uwdata/mosaic-core";
 import { createClassComponent } from "svelte/legacy";
 
@@ -99,6 +99,10 @@ export interface EmbeddingAtlasProps {
 
   /** A callback when the current filter predicate changes (e.g., due to brush or click interactions). */
   onPredicateChange?: ((predicate: string | null) => void) | null;
+
+  /** A callback when embedding cluster labels are generated or change.
+   *  Fires after label recomputation when the label set materially changes. */
+  onLabelsChange?: ((labels: LabelWithBounds[]) => void) | null;
 
   /** Model context API where the component will register its tools to. */
   modelContext?: ModelContextAPI | null;

--- a/packages/viewer/src/charts/chart.ts
+++ b/packages/viewer/src/charts/chart.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 Apple Inc. Licensed under MIT License.
 
-import type { EmbeddingViewConfig, Label } from "@embedding-atlas/component";
+import type { EmbeddingViewConfig, Label, LabelWithBounds } from "@embedding-atlas/component";
 import type { Coordinator, Selection } from "@uwdata/mosaic-core";
 import type { Draft } from "immer";
 import type { Readable, Writable } from "svelte/store";
@@ -117,6 +117,9 @@ export interface ChartContext {
 
   /** Labels for the embedding view. */
   embeddingViewLabels?: Label[] | null;
+
+  /** Callback when embedding cluster labels change. */
+  onLabelsChange?: ((labels: LabelWithBounds[]) => void) | null;
 }
 
 /** Props passed into a chart view. */

--- a/packages/viewer/src/charts/embedding/Embedding.svelte
+++ b/packages/viewer/src/charts/embedding/Embedding.svelte
@@ -281,6 +281,7 @@
     }}
     labels={context.embeddingViewLabels}
     cache={context.persistentCache}
+    onLabelsChange={context.onLabelsChange}
     additionalFields={isDefaultTable
       ? Object.fromEntries((context.tables[context.table]?.columns ?? []).map((c) => [c.name, c.name]))
       : {}}

--- a/packages/viewer/src/stores/embedding_atlas_store.ts
+++ b/packages/viewer/src/stores/embedding_atlas_store.ts
@@ -132,6 +132,7 @@ export class EmbeddingAtlasStore {
       highlightScorer: writable(embeddingHighlightScorer()),
       embeddingViewConfig: options.embeddingViewConfig,
       embeddingViewLabels: options.embeddingViewLabels,
+      onLabelsChange: options.onLabelsChange,
     };
 
     this.search.result.subscribe((result) => {


### PR DESCRIPTION
Expose generated cluster labels (with stable ids and data-coordinate rects) via an onLabelsChange callback on EmbeddingView, EmbeddingViewMosaic, and EmbeddingAtlas; fires only when the label set materially changes after recomputation.

Fixes #142